### PR TITLE
refactored to a newable object, and updated the examples

### DIFF
--- a/site/source/pages/api-reference/index.hbs
+++ b/site/source/pages/api-reference/index.hbs
@@ -3,7 +3,7 @@ title: API Reference
 layout: documentation.hbs
 ---
 
-# Esri Cedar API Reference
+# (NOT CURRENT) Esri Cedar API Reference
 
 ## Public Methods
 * [`Cedar.show`]({{assets}}api-reference/show.html)

--- a/site/source/pages/examples/index.hbs
+++ b/site/source/pages/examples/index.hbs
@@ -12,12 +12,11 @@ layout: example.hbs
 {{#markdown}}
 ```html
 {{>example-code-header}}
-  //render
-  Cedar.show({
+  var cedar = new Cedar();
+  cedar.show({
     elementId: "#chart",
-    spec: "/data/charts/scatter-chart.json"
+    spec: "{{assets}}data/charts/simple-scatter-chart.json"
   });
- 
 {{>example-code-footer}}
 ```
 {{/markdown}}
@@ -26,8 +25,8 @@ layout: example.hbs
 
 <script>
 
-  //render
-  Cedar.show({
+  var cedar = new Cedar();
+  cedar.show({
     elementId: "#chart",
     spec: "{{assets}}data/charts/simple-scatter-chart.json"
   });

--- a/site/source/pages/examples/scatter-events.hbs
+++ b/site/source/pages/examples/scatter-events.hbs
@@ -18,33 +18,23 @@ layout: example.hbs
 ```html
 
 {{>example-code-header}}
-  //render
-  function showItem(item){
+ function showItem(data){
     var tmpl = document.getElementById("school-detail-template").innerHTML;
     compiled = _.template(tmpl);
-
-    document.getElementById('details').innerHTML = compiled(item.datum.data.attributes);
+    document.getElementById('details').innerHTML = compiled(data);
   }
-
-  var cb = function(err, chart){
-    chart.on('mouseover', function(evt, item){
-      console.log('mouseover ' + evt.currentTarget);
-      
-    });
-    chart.on('mouseout', function(evt, item){
-      console.log('mouseout');
-      
-    });
-    chart.on('click', function(evt, item){
-      console.log('click');
-      showItem(item);
-    });
-  };
-
-  Cedar.show({
+  
+  var chart = new Cedar();
+  //attach handlers before the view exists
+  chart.on('mouseover', showItem);
+  //show the chart
+  chart.show({
     elementId: "#chart",
     spec: "{{assets}}data/charts/evt-scatter-chart.json"
-  }, cb);
+  });
+  //add more handlers after starting chart creation
+  chart.on('mouseout', showItem);
+  chart.on('click', showItem);
  
 {{>example-code-footer}}
 ```
@@ -64,30 +54,28 @@ layout: example.hbs
 
 <script>
   //render
-function showItem(item){
+  function showItem(data){
     var tmpl = document.getElementById("school-detail-template").innerHTML;
     compiled = _.template(tmpl);
-
-    document.getElementById('details').innerHTML = compiled(item.datum.data.attributes);
+    document.getElementById('details').innerHTML = compiled(data);
+  }
+  function report(data){
+    console.log('caught event ' + data);
   }
 
-  var cb = function(err, chart){
-    chart.on('mouseover', function(evt, item){
-      console.log('mouseover ' + evt.currentTarget);
-      
-    });
-    chart.on('mouseout', function(evt, item){
-      console.log('mouseout');
-      
-    });
-    chart.on('click', function(evt, item){
-      console.log('click');
-      showItem(item);
-    });
-  };
 
-  Cedar.show({
+
+  var chart = new Cedar();
+  //attach handlers before the view exists
+  chart.on('mouseover', report);
+  
+  chart.show({
     elementId: "#chart",
     spec: "{{assets}}data/charts/evt-scatter-chart.json"
-  }, cb);
+  });
+  //and after
+  chart.on('mouseout', report);
+  chart.on('click', showItem);
+
+
 </script>

--- a/site/source/pages/examples/simple-bar.hbs
+++ b/site/source/pages/examples/simple-bar.hbs
@@ -12,10 +12,11 @@ layout: example.hbs
 {{#markdown}}
 ```html
 {{>example-code-header}}
-  //render
-  Cedar.show({
+  
+  var cedar = new Cedar();
+  cedar.show({
     elementId: "#chart",
-    spec: "/data/charts/simple-pie-chart.json"
+    spec: "{{assets}}data/charts/simple-bar-chart.json"
   });
  
 {{>example-code-footer}}
@@ -25,7 +26,8 @@ layout: example.hbs
 
 <script>
   //render
-  Cedar.show({
+  var cedar = new Cedar();
+  cedar.show({
     elementId: "#chart",
     spec: "{{assets}}data/charts/simple-bar-chart.json"
   });

--- a/site/source/pages/examples/simple-pie.hbs
+++ b/site/source/pages/examples/simple-pie.hbs
@@ -12,10 +12,10 @@ layout: example.hbs
 {{#markdown}}
 ```html
 {{>example-code-header}}
-  //render
-  Cedar.show({
+  var cedar = new Cedar();
+  cedar.show({
     elementId: "#chart",
-    spec: "/data/charts/simple-pie-chart.json"
+    spec: "{{assets}}data/charts/simple-pie-chart.json"
   });
  
 {{>example-code-footer}}
@@ -24,8 +24,9 @@ layout: example.hbs
 
 
 <script>
-  //render
-  Cedar.show({
+  
+  var cedar = new Cedar();
+  cedar.show({
     elementId: "#chart",
     spec: "{{assets}}data/charts/simple-pie-chart.json"
   });

--- a/site/source/pages/examples/simple-scatter.hbs
+++ b/site/source/pages/examples/simple-scatter.hbs
@@ -11,10 +11,10 @@ layout: example.hbs
 {{#markdown}}
 ```html
 {{>example-code-header}}
-  //render
-  Cedar.show({
+  var cedar = new Cedar();
+  cedar.show({
     elementId: "#chart",
-    spec: "/data/charts/scatter-chart.json"
+    spec: "{{assets}}data/charts/simple-scatter-chart.json"
   });
  
 {{>example-code-footer}}
@@ -24,9 +24,8 @@ layout: example.hbs
 
 
 <script>
-
-  //render
-  Cedar.show({
+  var cedar = new Cedar();
+  cedar.show({
     elementId: "#chart",
     spec: "{{assets}}data/charts/simple-scatter-chart.json"
   });

--- a/site/source/pages/examples/template-from-url.hbs
+++ b/site/source/pages/examples/template-from-url.hbs
@@ -10,37 +10,7 @@ layout: example.hbs
 {{#markdown}}
 ```html
 {{>example-code-header}}
-  var fieldMappings = {
-    "x": "POPULATION_ENROLLED_2008",
-    "y": "SQUARE_FOOTAGE",
-    "color":"FACUSE"
-  }
-  var serviceUrl = "http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5"
-  var tmplUrl = "/data/templates/scatter-template.json";
-  Cedar.getJson(tmplUrl, function(err,template){
-    if(err){
-      console.error(err);
-      return;
-    }
-    //cook the spec
-    var chartJson = Cedar.create(template, serviceUrl, fieldMappings);
-    console.info()
-    var opts = {
-      elementId: "#chart",
-      spec: chartJson
-    };
-
-    //render
-    Cedar.show( opts );
-
-  });
-{{>example-code-footer}}
-```
-{{/markdown}}
-
-
-
-<script>
+  var cedar = new Cedar();
 
   var fieldMappings = {
     "x": "POPULATION_ENROLLED_2008",
@@ -49,13 +19,14 @@ layout: example.hbs
   }
   var serviceUrl = "http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5"
   var tmplUrl = "{{assets}}data/templates/scatter-template.json";
+
   Cedar.getJson(tmplUrl, function(err,template){
     if(err){
       console.error(err);
       return;
     }
     //cook the spec
-    var chartJson = Cedar.create(template, serviceUrl, fieldMappings);
+    var chartJson = cedar.create(template, serviceUrl, fieldMappings);
     console.info()
     var opts = {
       elementId: "#chart",
@@ -63,7 +34,41 @@ layout: example.hbs
     };
 
     //render
-    Cedar.show( opts );
+    cedar.show( opts );
+
+  });
+{{>example-code-footer}}
+```
+{{/markdown}}
+
+
+
+<script>  
+  var cedar = new Cedar();
+
+  var fieldMappings = {
+    "x": "POPULATION_ENROLLED_2008",
+    "y": "SQUARE_FOOTAGE",
+    "color":"FACUSE"
+  }
+  var serviceUrl = "http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5"
+  var tmplUrl = "{{assets}}data/templates/scatter-template.json";
+
+  Cedar.getJson(tmplUrl, function(err,template){
+    if(err){
+      console.error(err);
+      return;
+    }
+    //cook the spec
+    var chartJson = cedar.create(template, serviceUrl, fieldMappings);
+    console.info()
+    var opts = {
+      elementId: "#chart",
+      spec: chartJson
+    };
+
+    //render
+    cedar.show( opts );
 
   });
 

--- a/site/source/pages/index.hbs
+++ b/site/source/pages/index.hbs
@@ -12,7 +12,9 @@ layout: page.hbs
 
 
 <script>
-Cedar.show({
+
+var cedar = new Cedar();
+cedar.show({
     elementId: "#chart",
     spec: "{{assets}}data/charts/home-scatter-chart.json"
   });


### PR DESCRIPTION
Examples are updated. Basic usage is now:

```
 var cedar = new Cedar();
 cedar.show({
     elementId: "#chart",
     spec: "data/charts/simple-bar-chart.json"
   });
```

The intent is that now we have a newable object that can hold state, we can change the api more easily, but did not want to expand this scope to include those changed
