### PR TITLE
Aggregation function no longer hard-coded to "sum"

### DIFF
--- a/site/source/data/templates/bar.json
+++ b/site/source/data/templates/bar.json
@@ -1,8 +1,16 @@
 {
   "inputs": [
-    {"name": "count", "type": ["numeric","string"], "required": true},
-    {"name": "group", "type": ["string"], "required": false}
+    { "name": "count", "type": [ "numeric", "string" ], "required": true },
+    { "name": "group", "type": [ "string" ], "required": false }
   ],
+  "query": {
+    "groupByFieldsForStatistics": "{group.field}",
+    "outStatistics": [{
+        "statisticType": "sum",
+        "onStatisticField": "{count.field}",
+        "outStatisticFieldName": "{count.field}_SUM"
+    }]
+  },
   "template":{
     "height": 325,
     "width": 850,
@@ -34,7 +42,7 @@
           "enter": {
             "width": {"band": true, "offset": -1, "scale": "x"},
             "x": {"field": "data.attributes.{group.field}", "scale": "x"},
-            "y": {"field": "data.attributes.{count.field}_SUM", "scale": "y"},
+            "y": {"field": "data.attributes.{query.outStatistics.0.outStatisticFieldName}", "scale": "y"},
             "y2": {"scale": "y", "value": 0 }
           },
           "hover": {
@@ -60,7 +68,7 @@
       {
         "domain": {
           "data": "table",
-          "field": "data.attributes.{count.field}_SUM"
+          "field": "data.attributes.{query.outStatistics.0.outStatisticFieldName}"
         },
         "name": "y",
         "nice": true,

--- a/site/source/data/templates/bar.json
+++ b/site/source/data/templates/bar.json
@@ -1,7 +1,7 @@
 {
   "inputs": [
-    { "name": "count", "type": [ "numeric", "string" ], "required": true },
-    { "name": "group", "type": [ "string" ], "required": false }
+    { "name": "count", "type": [ "numeric", "string" ], "required": false },
+    { "name": "group", "type": [ "string" ], "required": true }
   ],
   "query": {
     "groupByFieldsForStatistics": "{group.field}",


### PR DESCRIPTION
@ajturner 
Please have a look. Does this look correct from the overall architecture perspective?

Trying to resolve #61 there. To achieve that, I am removing hard-coded "sum" statistic type as well as "_SUM" suffix. Instead of being hard-coded, it is now defined by `specification` explicitly. User can choose to override aggregation options in specification or via dataset.query.

BTW, I may have removed Underscore dependency as a part of this fix.