### PR TITLE
Added UMD block to cedar.js so it plays well w/ AMD

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,34 +8,14 @@ module.exports = function(grunt) {
                   '*   Apache License' +
                   '*/\n';
 
-  var umdHeader = '(function (factory) {\n' +
-                  '  //define an AMD module that relies on \'leaflet\'\n' +
-                  '  if (typeof define === \'function\' && define.amd) {\n' +
-                  '    define([\'leaflet\'], function (L) {\n' +
-                  '      return factory(L);\n' +
-                  '    });\n' +
-                  '  //define a common js module that relies on \'leaflet\'\n' +
-                  '  } else if (typeof module === \'object\' && typeof module.exports === \'object\') {\n' +
-                  '    module.exports = factory(require(\'leaflet\'));\n' +
-                  '  }\n\n' +
-                  '  if(typeof window !== \'undefined\' && window.L){\n' +
-                  '    factory(window.L);\n' +
-                  '  }\n' +
-                  '}(function (L) {\n';
-
-  var umdFooter = '\n\n  return EsriLeaflet;\n' +
-                  '}));';
-
   var cedar_vega_d3 = [
     'bower_components/d3/d3.js',
     'bower_components/vega/vega.js',
-    'bower_components/underscore/underscore.js',
     'src/cedar.js'
   ];
 
   var cedar_vega = [
     'bower_components/vega/vega.js',
-    'bower_components/underscore/underscore.js',
     'src/cedar.js'
   ];
 
@@ -138,9 +118,7 @@ module.exports = function(grunt) {
     concat: {
       options: {
         sourceMap: true,
-        separator: '\n\n',
-        //banner: copyright + umdHeader,
-        //footer: umdFooter,
+        separator: '\n\n'
       },
       cedar_vega_d3: {
         src: cedar_vega_d3,
@@ -166,9 +144,7 @@ module.exports = function(grunt) {
         //    except: ['d3', 'vg', 'cedar']
         // },
         preserveComments: 'some',
-        report: 'gzip',
-        //banner: copyright + umdHeader,
-        //footer: umdFooter,
+        report: 'gzip'
       },
       dist: {
         files: {

--- a/src/cedar.js
+++ b/src/cedar.js
@@ -5,7 +5,22 @@
  * that leverages vega + d3 internally.
  */
 
-(function(window){
+(function (factory) {
+  'use strict';
+  //define an AMD module that relies on 'vega'
+  if (typeof define === 'function' && define.amd) {
+    define(['vega', 'd3'], function (vg, d3) {
+      return factory(vg, d3);
+    });
+  //define a common js module that relies on 'vega'
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory(require('vega'), require('d3'));
+  }
+
+  if (typeof window !== 'undefined' && window.vg && window.d3) {
+    window.Cedar = factory(window.vg, window.d3);
+  }
+} (function (vg, d3) {
   'use strict';
 
 /**
@@ -740,6 +755,5 @@ Cedar._serializeQueryParams = function(params) {
   return queryString;
 };
 
-window.Cedar = Cedar;
-
-})(window);
+  return Cedar;
+}));


### PR DESCRIPTION
- Added UMD block to cedar.js
- removed UMD header/footer related code from Gruntfile.js - if this is needed later we can use [grunt- umd](https://www.npmjs.com/package/grunt-umd)
- removed underscore from builds as it's no longer used by Cedar (it is still used by the site, which loads it via a script tag)

The updated site is live here (still using Cedar global): http://tomwayson.github.io/cedar/ .

An example of how to load Cedar w/ and it's deps via AMD see:

https://gist.github.com/tomwayson/8ea426069e639886682c
http://bl.ocks.org/tomwayson/8ea426069e639886682c

That could be added as example page in the docs site w/ a little effort.