### PR TITLE
Added Events to callbacks for Tooltips & Esri styling

### DIFF
--- a/site/source/data/templates/bar-complex.json
+++ b/site/source/data/templates/bar-complex.json
@@ -18,10 +18,10 @@
         "scale":"x",
         "properties": {
           "ticks": {
-             "stroke": {"value": "#444"}
+             "stroke": {"value": "#dbdad9"}
           },
           "labels": {
-            "fill": {"value": "#444"},
+            "fill": {"value": "#999"},
             "angle": {"value": 50},
             "fontSize": {"value": 7},
             "align": {"value": "left"},
@@ -29,7 +29,7 @@
             "dx": {"value": 3}
           },
           "axis": {
-             "stroke": {"value": "#444"},
+             "stroke": {"value": "#dbdad9"},
              "strokeWidth": {"value": 1.5}
           }
         }
@@ -86,12 +86,12 @@
           },
           "hover": {
             "fill": {
-              "value": "green"
+              "value": "#29b6ea"
             }
           },
           "update": {
             "fill": {
-              "value": "#ccc"
+              "value": "#0079c1"
             }
           }
         },

--- a/site/source/data/templates/bar.json
+++ b/site/source/data/templates/bar.json
@@ -20,9 +20,17 @@
         "type": "x",
         "scale": "x",
         "titleOffset": 45,
-        "title": "{group.label}",
+        "title": "{group.label}",          
         "properties": {
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
           "labels": {
+            "fill": {"value": "#999"},
             "angle": {"value": 50},
             "align": {"value": "left"},
             "baseline": {"value": "middle"}
@@ -47,10 +55,10 @@
             "y2": {"scale": "y", "value": 0 }
           },
           "hover": {
-            "fill": {"value": "#1c5d87"}
+            "fill": {"value": "#29b6ea"}
           },
           "update": {
-            "fill": {"value": "#256e9d"}
+            "fill": {"value": "#0079c1"}
           }
         },
         "type": "rect"

--- a/site/source/data/templates/bar.json
+++ b/site/source/data/templates/bar.json
@@ -1,17 +1,9 @@
 {
   "inputs": [
-    { "name": "count", "type": [ "numeric", "string" ], "required": false },
-    { "name": "group", "type": [ "string" ], "required": true }
+    { "name": "x", "type": [ "numeric", "string" ], "required": false },
+    { "name": "y", "type": [ "string" ], "required": true }
   ],
-  "query": {
-    "orderByFields": "{count.field}_SUM",
-    "groupByFieldsForStatistics": "{group.field}",
-    "outStatistics": [{
-        "statisticType": "sum",
-        "onStatisticField": "{count.field}",
-        "outStatisticFieldName": "{count.field}_SUM"
-    }]
-  },
+  "query": {},
   "template":{
     "height": 325,
     "width": 850,
@@ -20,7 +12,7 @@
         "type": "x",
         "scale": "x",
         "titleOffset": 45,
-        "title": "{group.label}",          
+        "title": "{x.label}",          
         "properties": {
           "title": {
             "fontSize": {"value": 15},
@@ -46,7 +38,7 @@
         "type": "y",
         "scale": "y",
         "titleOffset": 45,
-        "title": "{count.label}",          
+        "title": "{y.label}",          
         "properties": {
           "title": {
             "fontSize": {"value": 15},
@@ -78,8 +70,8 @@
         "properties": {
           "enter": {
             "width": {"band": true, "offset": -1, "scale": "x"},
-            "x": {"field": "data.attributes.{group.field}", "scale": "x"},
-            "y": {"field": "data.attributes.{query.outStatistics.0.outStatisticFieldName}", "scale": "y"},
+            "x": {"field": "data.attributes.{x.field}", "scale": "x"},
+            "y": {"field": "data.attributes.{y.field}", "scale": "y"},
             "y2": {"scale": "y", "value": 0 }
           },
           "hover": {
@@ -96,7 +88,7 @@
       {
         "domain": {
           "data": "table",
-          "field": "data.attributes.{group.field}"
+          "field": "data.attributes.{x.field}"
         },
         "name": "x",
         "range": "width",
@@ -105,7 +97,7 @@
       {
         "domain": {
           "data": "table",
-          "field": "data.attributes.{query.outStatistics.0.outStatisticFieldName}"
+          "field": "data.attributes.{y.field}"
         },
         "name": "y",
         "nice": true,

--- a/site/source/data/templates/bar.json
+++ b/site/source/data/templates/bar.json
@@ -22,6 +22,11 @@
         "titleOffset": 45,
         "title": "{group.label}",          
         "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },          
           "axis": {
              "stroke": {"value": "#dbdad9"},
              "strokeWidth": {"value": 1.5}
@@ -36,7 +41,30 @@
             "baseline": {"value": "middle"}
           }
         }
-      }
+      },
+      {
+        "type": "y",
+        "scale": "y",
+        "titleOffset": 45,
+        "title": "{count.label}",          
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },          
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"}
+          }
+        }
+      }      
     ],
     "data": [
       {

--- a/site/source/data/templates/bubble.json
+++ b/site/source/data/templates/bubble.json
@@ -50,7 +50,29 @@
         "scale": "x",
         "offset": 5,
         "ticks": 5,
-        "title": "{x.label}"
+        "title": "{x.label}",
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "fontSize": {"value": 14},
+            "align": {"value": "left"},
+            "baseline": {"value": "middle"},
+            "dx": {"value": 3}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          }
+        }        
       },
       {
         "type": "y",
@@ -58,7 +80,27 @@
         "offset": 5,
         "ticks": 5,
         "title": "{y.label}",
-        "titleOffset": 50
+        "titleOffset": 50,
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "fontSize": {"value": 14},
+            "align": {"value": "right"}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          }
+        }
       }
     ],
     "legends": [
@@ -67,10 +109,16 @@
         "offset": 0,
         "size": "size",
         "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
           "symbols": {
-            "strokeWidth": {"value": 1},
-            "fill": { "value": "#256e9d" },
-            "fillOpacity": {"value": 0.2 }
+            "strokeWidth": {"value": 2},
+            "stroke": {"value": "#0079c1"},
+            "fill": { "value": "#fff" },
+            "fillOpacity": {"value": 0.4 }
           }
         }
       }
@@ -91,20 +139,21 @@
               "scale": "y",
               "field": "data.attributes.{y.field}"
             },
-            "strokeWidth": {"value": 1},
-            "fillOpacity": {"value": 0.2 },
+            "strokeWidth": {"value": 2},
+            "fillOpacity": {"value": 0.4 },
             "size": { 
               "scale": "size",
               "field": "data.attributes.{size.field}"
             }
           },
           "update": {
-            "fill": { "value": "#256e9d" },
-            "stroke": {"value": "#256e9d"}
+            "fill": { "value": "#fff" },
+            "stroke": {"value": "#0079c1"}
           },
           "hover": {
-            "fill": {"value": "#888"},
-            "stroke": {"value": "#1c5d87"}
+            "fill": {"value": "#0079c1"},
+            "fillOpacity": {"value": 0.6 },
+            "stroke": {"value": "#0079c1"}
           }
         }
       }

--- a/site/source/data/templates/horizontal.json
+++ b/site/source/data/templates/horizontal.json
@@ -22,7 +22,20 @@
         "titleOffset": 45,
         "title": "{count.label}",
         "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
           "labels": {
+            "fill": {"value": "#999"},
             "angle": {"value": 0},
             "baseline": {"value": "middle"}
           }
@@ -34,7 +47,20 @@
         "titleOffset": 25,
         "title": "{group.label}",
         "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
           "labels": {
+            "fill": {"value": "#999"},
             "angle": {"value": 0},
             "baseline": {"value": "middle"}
           }
@@ -58,10 +84,10 @@
             "x": {"scale": "x", "value": 0 }
           },
           "hover": {
-            "fill": {"value": "#1c5d87"}
+            "fill": {"value": "#29b6ea"}
           },
           "update": {
-            "fill": {"value": "#256e9d"}
+            "fill": {"value": "#0079c1"}
           }
         },
         "type": "rect"

--- a/site/source/data/templates/pie.json
+++ b/site/source/data/templates/pie.json
@@ -54,10 +54,10 @@
             "stroke": {"value": "#fff"}
           },
           "update": {
-            "fill": {"value": "#ccc"}
+            "fill": {"value": "#0079c1"}
           },
           "hover": {
-            "fill": {"value": "green"}
+            "fill": {"value": "#29b6ea"}
           }
         }
       },
@@ -68,7 +68,7 @@
           "enter": {
             "y": {"field": "y"},
             "x": {"field": "x"},
-            "fill": {"value": "#000"},
+            "fill": {"value": "#fff"},
             "align": {"value": "center"},
             "baseline": {"value": "middle"},
             "text": {"field": "data.attributes.{group.field}"}

--- a/site/source/data/templates/scatter-complex.json
+++ b/site/source/data/templates/scatter-complex.json
@@ -9,7 +9,7 @@
     "height": 500,
     "data": [
       {
-        "name": "iris",
+        "name": "table",
         "format": {
           "property": "features"
         }
@@ -21,7 +21,7 @@
         "nice": true,
         "range": "width",
         "domain": {
-          "data": "iris",
+          "data": "table",
           "field": "data.attributes.{x.field}"
         }
       },
@@ -30,7 +30,7 @@
         "nice": true,
         "range": "height",
         "domain": {
-          "data": "iris",
+          "data": "table",
           "field": "data.attributes.{y.field}"
         }
       },
@@ -38,7 +38,7 @@
         "name": "c",
         "type": "ordinal",
         "domain": {
-          "data": "iris",
+          "data": "table",
           "field": "data.attributes.{color.field}"
         },
         "range": [
@@ -109,7 +109,7 @@
       {
         "type": "symbol",
         "from": {
-          "data": "iris"
+          "data": "table"
         },
         "properties": {
           "enter": {

--- a/site/source/data/templates/scatter.json
+++ b/site/source/data/templates/scatter.json
@@ -9,7 +9,7 @@
     "height": 500,
     "data": [
       {
-        "name": "iris",
+        "name": "table",
         "format": {
           "property": "features"
         }
@@ -21,7 +21,7 @@
         "nice": true,
         "range": "width",
         "domain": {
-          "data": "iris",
+          "data": "table",
           "field": "data.attributes.{x.field}"
         }
       },
@@ -30,7 +30,7 @@
         "nice": true,
         "range": "height",
         "domain": {
-          "data": "iris",
+          "data": "table",
           "field": "data.attributes.{y.field}"
         }
       },
@@ -38,7 +38,7 @@
         "name": "c",
         "type": "ordinal",
         "domain": {
-          "data": "iris",
+          "data": "table",
           "field": "data.attributes.{color.field}"
         },
         "range": [
@@ -54,7 +54,24 @@
         "scale": "x",
         "offset": 5,
         "ticks": 5,
-        "title": "{x.label}"
+        "title": "{x.label}",
+        "properties": {
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "fontSize": {"value": 14},
+            "align": {"value": "left"},
+            "baseline": {"value": "middle"},
+            "dx": {"value": 3}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          }
+        }        
       },
       {
         "type": "y",
@@ -62,7 +79,22 @@
         "offset": 5,
         "ticks": 5,
         "title": "{y.label}",
-        "titleOffset": 50
+        "titleOffset": 50,
+        "properties": {
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "fontSize": {"value": 14},
+            "align": {"value": "right"}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          }
+        }
       }
     ],
     "legends": [
@@ -86,7 +118,7 @@
       {
         "type": "symbol",
         "from": {
-          "data": "iris"
+          "data": "table"
         },
         "properties": {
           "enter": {

--- a/site/source/data/templates/scatter.json
+++ b/site/source/data/templates/scatter.json
@@ -56,6 +56,11 @@
         "ticks": 5,
         "title": "{x.label}",
         "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
           "ticks": {
              "stroke": {"value": "#dbdad9"}
           },
@@ -81,6 +86,11 @@
         "title": "{y.label}",
         "titleOffset": 50,
         "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
           "ticks": {
              "stroke": {"value": "#dbdad9"}
           },

--- a/site/source/data/templates/time-dots.json
+++ b/site/source/data/templates/time-dots.json
@@ -52,7 +52,28 @@
       }
     ],
     "axes": [
-      {"type": "x", "scale": "x"}
+      {
+        "type": "x", 
+        "scale": "x",
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "fontSize": {"value": 13}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1}
+          }
+        }
+      }
     ],
     "legends": [
       {

--- a/site/source/data/templates/time.json
+++ b/site/source/data/templates/time.json
@@ -36,6 +36,11 @@
         "type": "x", 
         "scale": "x",
         "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
           "ticks": {
              "stroke": {"value": "#dbdad9"}
           },

--- a/site/source/data/templates/time.json
+++ b/site/source/data/templates/time.json
@@ -32,10 +32,61 @@
       }
     ],
     "axes": [
-      {"type": "x", "scale": "x"},
-      {"type": "y", "scale": "y"}
+      {
+        "type": "x", 
+        "scale": "x",
+        "properties": {
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "fontSize": {"value": 13}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1}
+          }
+        }
+      },
+      {
+        "type": "y", 
+        "scale": "y",
+        "properties": {
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "fontSize": {"value": 13}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"}
+          }
+        }
+      }
     ],
     "marks": [
+      {
+        "type": "symbol",
+        "from": {"data": "table"},
+        "properties": {
+          "enter": {
+            "x": {"scale": "x", "field": "data.attributes.{time.field}"},
+            "y": {"scale": "y", "field": "data.attributes.{value.field}"},
+            "stroke": {"value": "#0079c1"},
+            "fillOpacity": {
+              "value": 0.8
+            },
+            "hover": {
+              "fill": {"value": "#0079c1"}
+            },
+            "update": {
+              "fill": {"value": "#fff"}
+            }
+          }
+        }
+      },
       {
         "type": "line",
         "from": {"data": "table"},
@@ -44,7 +95,7 @@
             "x": {"scale": "x", "field": "data.attributes.{time.field}"},
             "y": {"scale": "y", "field": "data.attributes.{value.field}"},
             "y2": {"scale": "y", "value": 0},
-            "stroke": {"value": "steelblue"}
+            "stroke": {"value": "#0079c1"}
           }
         }
       }

--- a/site/source/pages/api/clearselection.hbs
+++ b/site/source/pages/api/clearselection.hbs
@@ -94,7 +94,7 @@ Clear all selections:
     //CHART EVENTS
     chart.on('mouseover', onChartHover);
 
-    function onChartHover(d) {
+    function onChartHover(e,d) {
       
       //get selected value for attribute in chart marker
       var selected = d[dataset.mappings.group.field];

--- a/site/source/pages/api/off.hbs
+++ b/site/source/pages/api/off.hbs
@@ -36,7 +36,7 @@ Remove all event handlers for the specified event. Should be called when a chart
 <script>
 
    //define a handler for chart events 
-  function showItem(data){
+  function showItem(event,data){
     //dump data to console...
     console.dir(data);
   }

--- a/site/source/pages/api/on.hbs
+++ b/site/source/pages/api/on.hbs
@@ -14,7 +14,7 @@ Bind event handler functions to the chart.
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `event` | `string` | yes | Name of the interaction event to bind the function. (`mouseover`) |
-| `fn` | `function` | yes | Function that is called when the event occurs.  |
+| `fn` | `function` | yes | Function(event, data) that is called when the event occurs.  |
 
 
 ### Available Events
@@ -41,7 +41,9 @@ When a handler is fired, the data associated with the chart element is passed al
 <script>
 
    //define a handler for chart events 
-  function showItem(data){
+  function showItem(event,data){
+    //dump event to console such as mouse location...
+    console.dir(event);
     //dump data to console...
     console.dir(data);
   }

--- a/site/source/pages/api/select.hbs
+++ b/site/source/pages/api/select.hbs
@@ -90,7 +90,7 @@ Selects chart markers based on "hover" style definition.
     //CHART EVENTS
     chart.on('mouseover', onChartHover);
 
-    function onChartHover(d) {
+    function onChartHover(e,d) {
       
       //get selected value for attribute in chart marker
       var selected = d[dataset.mappings.group.field];

--- a/site/source/pages/examples/bar-map-integration.hbs
+++ b/site/source/pages/examples/bar-map-integration.hbs
@@ -15,7 +15,6 @@ layout: example.hbs
 
 {{#markdown}}
 ```html
-{{>example-code-header}}
   
   require(["esri/map", "esri/layers/FeatureLayer", "esri/symbols/SimpleMarkerSymbol", "esri/symbols/SimpleLineSymbol",
     "esri/renderers/SimpleRenderer",  "esri/renderers/UniqueValueRenderer", "esri/Color", "dojo/domReady!"], function(Map, FeatureLayer, 
@@ -94,7 +93,6 @@ layout: example.hbs
 
     } 
   });
-{{>example-code-footer}}
 ```
 {{/markdown}}
 

--- a/site/source/pages/examples/bar-map-integration.hbs
+++ b/site/source/pages/examples/bar-map-integration.hbs
@@ -78,7 +78,7 @@ layout: example.hbs
     //CHART EVENTS
     chart.on('mouseover', onChartHover);
 
-    function onChartHover(d) {
+    function onChartHover(e,d) {
       
       //get selected value for attribute in chart marker
       var selected = d[dataset.mappings.group.field];
@@ -163,7 +163,7 @@ layout: example.hbs
     //CHART EVENTS
     chart.on('mouseover', onChartHover);
 
-    function onChartHover(d) {
+    function onChartHover(e,d) {
       
       //get selected value for attribute in chart marker
       var selected = d[dataset.mappings.group.field];

--- a/site/source/pages/examples/bar-map-leaflet-integration.hbs
+++ b/site/source/pages/examples/bar-map-leaflet-integration.hbs
@@ -77,7 +77,7 @@ layout: example.hbs
   //CHART EVENTS
   chart.on('mouseover', onChartHover);
 
-  function onChartHover(d) {
+  function onChartHover(e,d) {
     
     //get selected value for attribute in chart marker
     var selected = d[dataset.mappings.group.field];
@@ -161,7 +161,7 @@ layout: example.hbs
   //CHART EVENTS
   chart.on('mouseover', onChartHover);
 
-  function onChartHover(d) {
+  function onChartHover(e,d) {
     
     //get selected value for attribute in chart marker
     var selected = d[dataset.mappings.group.field];

--- a/site/source/pages/examples/bar-map-leaflet-integration.hbs
+++ b/site/source/pages/examples/bar-map-leaflet-integration.hbs
@@ -22,7 +22,6 @@ layout: example.hbs
 
 {{#markdown}}
 ```html
-{{>example-code-header}}
   
    //create a cedar chart
   var chart = new Cedar({"specification":"../data/templates/bar.json"});
@@ -100,7 +99,6 @@ layout: example.hbs
     });
 
   } 
-{{>example-code-footer}}
 ```
 {{/markdown}}
 

--- a/site/source/pages/examples/bar-spec-inlined.hbs
+++ b/site/source/pages/examples/bar-spec-inlined.hbs
@@ -11,7 +11,6 @@ layout: example.hbs
 
 {{#markdown}}
 ```html
-{{>example-code-header}}
 //create a cedar chart
   var chart = new Cedar();
 
@@ -123,7 +122,6 @@ layout: example.hbs
   chart.show({
     elementId: "#chart"
   });
-{{>example-code-footer}}
 ```
 {{/markdown}}
 

--- a/site/source/pages/examples/bar-spec-url.hbs
+++ b/site/source/pages/examples/bar-spec-url.hbs
@@ -17,7 +17,7 @@ layout: example.hbs
     font-size: 10px;    
   }
   .cedar-tooltip .title {
-    font-size: 15pt;
+    font-size: 13pt;
     font-weight: bold;
   }
   .cedar-tooltip .content {

--- a/site/source/pages/examples/bar-spec-url.hbs
+++ b/site/source/pages/examples/bar-spec-url.hbs
@@ -7,25 +7,6 @@ layout: example.hbs
 
 <h3>Specification and Data from URL</h3>
 
-<style type="text/css">
-  .cedar-tooltip {
-    background-color: #f36f22;
-    padding: 3px 10px;
-    color: #fff;
-    position: absolute;
-    z-index: 2000;
-    font-size: 10px;    
-  }
-  .cedar-tooltip .title {
-    font-size: 13pt;
-    font-weight: bold;
-  }
-  .cedar-tooltip .content {
-    font-size: 10pt;
-  }
-</style>
-
-
 <div id="tooltip-url" class="cedar-tooltip" style="display: none"></div>
 <div id="chart-url"></div>
 

--- a/site/source/pages/examples/bar-spec-url.hbs
+++ b/site/source/pages/examples/bar-spec-url.hbs
@@ -6,7 +6,28 @@ layout: example.hbs
 <h1>Bar Chart</h1>
 
 <h3>Specification and Data from URL</h3>
-<div id="bar-url"></div>
+
+<style type="text/css">
+  .cedar-tooltip {
+    background-color: #f36f22;
+    padding: 3px 10px;
+    color: #fff;
+    position: absolute;
+    z-index: 2000;
+    font-size: 10px;    
+  }
+  .cedar-tooltip .title {
+    font-size: 15pt;
+    font-weight: bold;
+  }
+  .cedar-tooltip .content {
+    font-size: 10pt;
+  }
+</style>
+
+
+<div id="tooltip-url" class="cedar-tooltip" style="display: none"></div>
+<div id="chart-url"></div>
 
 {{#markdown}}
 ```javascript
@@ -18,7 +39,8 @@ layout: example.hbs
 
 <h3>Inline Data</h3>
 
-<div id="bar-data"></div>
+<div id="tooltip-data" class="cedar-tooltip" style="display: none"></div>
+<div id="chart-data"></div>
 
 {{#markdown}}
 ```javascript
@@ -27,3 +49,4 @@ layout: example.hbs
 {{/markdown}}
 
 {{>example-bar-data}}
+

--- a/site/source/pages/examples/bubble.hbs
+++ b/site/source/pages/examples/bubble.hbs
@@ -63,9 +63,8 @@ layout: example.hbs
     })
   chart.on('mouseover', function(event,data){
       var cedartip = document.getElementById(tooltipurl.id);
-      console.log(event)
-      cedartip.style.top = event.pageY + "px";
-      cedartip.style.left = event.pageX+10 + "px";
+      cedartip.style.top = event.offsetY+40 + "px";
+      cedartip.style.left = event.offsetX+30 + "px";
       cedartip.style.display = "block";
       var content = "<span class='title'>" + tooltipurl.title + "</span><br />";
       content += "<p class='content'>" + tooltipurl.content + "</p>";

--- a/site/source/pages/examples/bubble.hbs
+++ b/site/source/pages/examples/bubble.hbs
@@ -5,6 +5,26 @@ layout: example.hbs
 
 <h1>Bubble Chart</h1>
   
+  <style type="text/css">
+  .cedar-tooltip {
+    background-color: #f36f22;
+    padding: 3px 10px;
+    color: #fff;
+    position: fixed;
+    z-index: 2000;
+    font-size: 10px;    
+  }
+  .cedar-tooltip .title {
+    font-size: 15pt;
+    font-weight: bold;
+  }
+  .cedar-tooltip .content {
+    font-size: 10pt;
+  }
+</style>
+
+
+<div id="tooltip" class="cedar-tooltip" style="display: none"></div>
 <div id="chart"></div>
 
 
@@ -49,9 +69,33 @@ layout: example.hbs
     }
   });
 
+  var tooltipurl = {
+    "id": "tooltip",
+    "title": "{NAME}",
+    "content": "{TOTAL_STUD} out of {CAPACITY} Students in {SQUARE_FOOTAGE} sq. ft."
+  }  
+
   chart.show({
     elementId: "#chart",
   });
+
+  chart.on('mouseout', function(event,data){
+      var cedartip = document.getElementById(tooltipurl.id);
+      cedartip.style.display = "none";
+    })
+  chart.on('mouseover', function(event,data){
+      var cedartip = document.getElementById(tooltipurl.id);
+      console.log(event)
+      cedartip.style.top = event.pageY + "px";
+      cedartip.style.left = event.pageX+10 + "px";
+      cedartip.style.display = "block";
+      var content = "<span class='title'>" + tooltipurl.title + "</span><br />";
+      content += "<p class='content'>" + tooltipurl.content + "</p>";
+
+      cedartip.innerHTML = content.replace( /\{(\w+)\}/g, function replacer(match, $1){
+        return data[$1];
+      } );
+    });  
 
 
 </script>

--- a/site/source/pages/examples/bubble.hbs
+++ b/site/source/pages/examples/bubble.hbs
@@ -29,8 +29,7 @@ layout: example.hbs
 
 
 {{#markdown}}
-```html
-{{>example-code-header}}
+```javascript
   var chart = new Cedar({
     "specification":"{{assets}}data/templates/bubble.json",
     "dataset":{
@@ -48,9 +47,7 @@ layout: example.hbs
     elementId: "#chart",
   });
 
- 
-{{>example-code-footer}}
-```
+ ```
 {{/markdown}}
 
 

--- a/site/source/pages/examples/bubble.hbs
+++ b/site/source/pages/examples/bubble.hbs
@@ -4,25 +4,6 @@ layout: example.hbs
 
 
 <h1>Bubble Chart</h1>
-  
-  <style type="text/css">
-  .cedar-tooltip {
-    background-color: #f36f22;
-    padding: 3px 10px;
-    color: #fff;
-    position: fixed;
-    z-index: 2000;
-    font-size: 10px;    
-  }
-  .cedar-tooltip .title {
-    font-size: 15pt;
-    font-weight: bold;
-  }
-  .cedar-tooltip .content {
-    font-size: 10pt;
-  }
-</style>
-
 
 <div id="tooltip" class="cedar-tooltip" style="display: none"></div>
 <div id="chart"></div>

--- a/site/source/pages/examples/complex-map-multiple-chart.hbs
+++ b/site/source/pages/examples/complex-map-multiple-chart.hbs
@@ -153,7 +153,7 @@
       scatter.update();
     }
 
-    function onChartHover(d) {
+    function onChartHover(e,d) {
       
       //get selected value for attribute in chart marker
       var selected = d[dataset.mappings.group.field];

--- a/site/source/pages/examples/drill-down.hbs
+++ b/site/source/pages/examples/drill-down.hbs
@@ -12,7 +12,6 @@ layout: example.hbs
 
 {{#markdown}}
 ```html
-{{>example-code-header}}
  
 var chart = new Cedar({
   "specification":"{{assets}}data/templates/bar.json"
@@ -65,7 +64,6 @@ chart.show({
 
 chart.on('click', facetChart);
  
-{{>example-code-footer}}
 ```
 {{/markdown}}
 

--- a/site/source/pages/examples/inlined-data.hbs
+++ b/site/source/pages/examples/inlined-data.hbs
@@ -4,15 +4,13 @@ layout: example.hbs
 ---
 
 
-<h1>Pass Data Directly to Chart</h1>
+<h1>Load data from another API</h1>
 
 <div id="chart"></div>
 
 
-
 {{#markdown}}
 ```html
-{{>example-code-header}}
   var chart = new Cedar({"specification":"{{assets}}data/templates/bar.json"});
   //fetch data from a json file
   var data = Cedar.getJson('{{assets}}data/feature-collection-data.json', function(err, data){
@@ -36,7 +34,7 @@ layout: example.hbs
     }else{
       console.error('Error loading data from file');
     }
-{{>example-code-footer}}
+
 ```
 ### Expected Format
 ```

--- a/site/source/pages/examples/map-to-chart-interaction.hbs
+++ b/site/source/pages/examples/map-to-chart-interaction.hbs
@@ -15,7 +15,6 @@ layout: example.hbs
 
 {{#markdown}}
 ```html
-{{>example-code-header}}
   
     require(["esri/map", "esri/layers/FeatureLayer", "esri/symbols/SimpleMarkerSymbol", "esri/symbols/SimpleLineSymbol",
     "esri/renderers/SimpleRenderer",  "esri/renderers/UniqueValueRenderer", "esri/Color", "esri/graphic", "dojo/domReady!"], function(Map, FeatureLayer, 
@@ -133,7 +132,6 @@ layout: example.hbs
 
 
   });
-{{>example-code-footer}}
 ```
 {{/markdown}}
 

--- a/site/source/pages/examples/map-to-chart-interaction.hbs
+++ b/site/source/pages/examples/map-to-chart-interaction.hbs
@@ -82,7 +82,7 @@ layout: example.hbs
     //CHART EVENTS
     chart.on('mouseover', onChartHover);
 
-    function onChartHover(d) {
+    function onChartHover(e,d) {
       
       //get selected value for attribute in chart marker
       var selected = d[dataset.mappings.group.field];
@@ -205,7 +205,7 @@ layout: example.hbs
     //CHART EVENTS
     chart.on('mouseover', onChartHover);
 
-    function onChartHover(d) {
+    function onChartHover(e,d) {
       
       //get selected value for attribute in chart marker
       var selected = d[dataset.mappings.group.field];

--- a/site/source/pages/examples/responsive-example.hbs
+++ b/site/source/pages/examples/responsive-example.hbs
@@ -12,7 +12,6 @@ layout: example.hbs
 
 {{#markdown}}
 ```html
-{{>example-code-header}}
   function drawChart() {
     //create a cedar chart - passing a url to the spec
     var chart = new Cedar({"specification":"{{assets}}data/templates/bar.json"});
@@ -71,7 +70,6 @@ layout: example.hbs
 
     chart.update();
   }
-{{>example-code-footer}}
 ```
 {{/markdown}}
 

--- a/site/source/pages/examples/responsive-example.hbs
+++ b/site/source/pages/examples/responsive-example.hbs
@@ -9,70 +9,6 @@ layout: example.hbs
 <div id="chart"></div>
 
 
-
-{{#markdown}}
-```html
-  function drawChart() {
-    //create a cedar chart - passing a url to the spec
-    var chart = new Cedar({"specification":"{{assets}}data/templates/bar.json"});
-
-    //create the dataset w/ mappings
-    var dataset = {
-      "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
-      "mappings":{
-        "group": {"field":"ZIP_CODE","label":"ZIP Code"},
-        "count": {"field":"TOTAL_STUD","label":"Total Students"}
-      }
-    };
-
-    //assign to the chart
-    chart.dataset = dataset;
-
-    var el = document.getElementById("chart");
-    var width = el.offsetWidth;
-    var height = el.offsetHeight;
-
-    chart.override = {
-      "height": height,
-      "width": width,
-      "marks": [{"properties": {
-          "hover": {"fill": {"value": "#3ba3d0"}},
-          "update": {"fill": {"value": "#7de6ff"}}
-        }
-      }]
-    };
-
-    //show the chart
-    chart.show({
-      elementId: "#chart"
-    });
-
-    window.chart = chart;
-  };
-
-
-  drawChart();
-
-  window.onresize = updateChart;
-
-  function updateChart() {
-    var el = document.getElementById("chart");
-    var width = el.offsetWidth;
-    
-    chart.override = {
-      "width": width,
-      "marks": [{"properties": {
-          "hover": {"fill": {"value": "#3ba3d0"}},
-          "update": {"fill": {"value": "#7de6ff"}}
-        }
-      }]
-    }
-
-    chart.update();
-  }
-```
-{{/markdown}}
-
 <script>
   function drawChart() {
     //create a cedar chart - passing a url to the spec
@@ -81,9 +17,16 @@ layout: example.hbs
     //create the dataset w/ mappings
     var dataset = {
       "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+      "query": {
+        "groupByFieldsForStatistics": [{
+          "statisticType": "sum", 
+          "onStatisticField": "TOTAL_STUD", 
+          "outStatisticFieldName": "TOTAL_STUD_SUM"
+        }]
+      },
       "mappings":{
-        "group": {"field":"ZIP_CODE","label":"ZIP Code"},
-        "count": {"field":"TOTAL_STUD","label":"Total Students"}
+        "x": {"field":"ZIP_CODE","label":"ZIP Code"},
+        "y": {"field":"TOTAL_STUD_SUM","label":"Total Students"}
       }
     };
 
@@ -97,9 +40,13 @@ layout: example.hbs
     chart.override = {
       "height": height,
       "width": width,
-      "marks": [{"properties": {
-          "hover": {"fill": {"value": "#3ba3d0"}},
-          "update": {"fill": {"value": "#7de6ff"}}
+      "axes": [{
+        "properties": {
+          "labels": {
+            "angle": {"value": 0},
+            "align": {"value": "center"},
+            "baseline": {"value": "middle"}
+          }
         }
       }]
     };
@@ -120,14 +67,30 @@ layout: example.hbs
   function updateChart() {
     var el = document.getElementById("chart");
     var width = el.offsetWidth;
-    
+    var labels;
+    if(width <= 200) {
+      labels = {
+        "fontSize": {"value": 0},
+      }
+    } else if (200 < width && width <= 600) {
+      labels = {
+        "angle": {"value": 50},
+        "align": {"value": "left"},
+        "baseline": {"value": "middle"}
+      }
+    } else {
+      labels = {
+        "angle": {"value": 0},
+        "align": {"value": "center"},
+        "baseline": {"value": "middle"}
+      }
+    }
+
     chart.override = {
       "width": width,
-      "marks": [{"properties": {
-          "hover": {"fill": {"value": "#3ba3d0"}},
-          "update": {"fill": {"value": "#7de6ff"}}
-        }
-      }]
+      "axes": [{"properties": {
+        "labels": labels
+      }}]
     }
 
     chart.update();

--- a/site/source/pages/examples/scatter-def-url.hbs
+++ b/site/source/pages/examples/scatter-def-url.hbs
@@ -10,7 +10,6 @@ layout: example.hbs
 
 {{#markdown}}
 ```html
-{{>example-code-header}}
   var chart = new Cedar({
     "specification":"{{assets}}data/templates/scatter.json",
     "dataset":{
@@ -29,7 +28,6 @@ layout: example.hbs
   });
 
  
-{{>example-code-footer}}
 ```
 {{/markdown}}
 

--- a/site/source/pages/examples/scatter-events.hbs
+++ b/site/source/pages/examples/scatter-events.hbs
@@ -22,9 +22,14 @@ layout: example.hbs
 ```html
 
 {{>example-code-header}}
+<<<<<<< HEAD
   var selectedItems = {};
 
   function compileTemplate(data) {
+=======
+  //define a handler for chart events 
+  function showItem(event,data){
+>>>>>>> Changed Event handlers to include event object for tooltip placement
     var tmpl = document.getElementById("school-detail-template").innerHTML;
     //this uses underscore's templating library, but it could use anything
     return _.template(tmpl)(data); 
@@ -92,9 +97,14 @@ layout: example.hbs
 </script>
 
 <script>
+<<<<<<< HEAD
   var selectedItems = {};
 
   function compileTemplate(data) {
+=======
+  //define a handler for chart events 
+  function showItem(event,data){
+>>>>>>> Changed Event handlers to include event object for tooltip placement
     var tmpl = document.getElementById("school-detail-template").innerHTML;
     //this uses underscore's templating library, but it could use anything
     return _.template(tmpl)(data); 

--- a/site/source/pages/examples/scatter-events.hbs
+++ b/site/source/pages/examples/scatter-events.hbs
@@ -21,29 +21,23 @@ layout: example.hbs
 {{#markdown}}
 ```html
 
-{{>example-code-header}}
-<<<<<<< HEAD
   var selectedItems = {};
 
   function compileTemplate(data) {
-=======
-  //define a handler for chart events 
-  function showItem(event,data){
->>>>>>> Changed Event handlers to include event object for tooltip placement
     var tmpl = document.getElementById("school-detail-template").innerHTML;
     //this uses underscore's templating library, but it could use anything
     return _.template(tmpl)(data); 
   }
 
-  function showItem(data){
+  function showItem(event,data){
     document.getElementById('details').innerHTML = compileTemplate(data);
   }
 
-  function hideItem(data){
+  function hideItem(event,data){
     document.getElementById('details').innerHTML = "";
   }
   
-  function toggleItem(data){
+  function toggleItem(event,data){
     if(selectedItems[data.NAME] === undefined || selectedItems[data.NAME] === null) {
       selectedItems[data.NAME] = data;
     } else {
@@ -81,7 +75,6 @@ layout: example.hbs
   chart.on('mouseover', showItem);
   chart.on('mouseout', hideItem);
   chart.on('click', toggleItem);
-{{>example-code-footer}}
 ```
 {{/markdown}}
 
@@ -97,28 +90,23 @@ layout: example.hbs
 </script>
 
 <script>
-<<<<<<< HEAD
   var selectedItems = {};
 
   function compileTemplate(data) {
-=======
-  //define a handler for chart events 
-  function showItem(event,data){
->>>>>>> Changed Event handlers to include event object for tooltip placement
     var tmpl = document.getElementById("school-detail-template").innerHTML;
     //this uses underscore's templating library, but it could use anything
     return _.template(tmpl)(data); 
   }
 
-  function showItem(data){
+  function showItem(event,data){
     document.getElementById('details').innerHTML = compileTemplate(data);
   }
 
-  function hideItem(data){
+  function hideItem(event,data){
     document.getElementById('details').innerHTML = "";
   }
   
-  function toggleItem(data){
+  function toggleItem(event,data){
     if(selectedItems[data.NAME] === undefined || selectedItems[data.NAME] === null) {
       selectedItems[data.NAME] = data;
     } else {

--- a/site/source/pages/examples/simple-pie.hbs
+++ b/site/source/pages/examples/simple-pie.hbs
@@ -11,7 +11,6 @@ layout: example.hbs
 
 {{#markdown}}
 ```html
-{{>example-code-header}}
   var chart = new Cedar({"specification":"{{assets}}data/templates/pie.json"});
   //create the dataset w/ mappings
   var dataset = {
@@ -25,7 +24,6 @@ layout: example.hbs
   chart.show({
     elementId: "#chart",
   }); 
-{{>example-code-footer}}
 ```
 {{/markdown}}
 

--- a/site/source/pages/examples/time.hbs
+++ b/site/source/pages/examples/time.hbs
@@ -3,9 +3,27 @@ title: Time Example
 layout: example.hbs
 ---
 
+<style type="text/css">
+  #cedar-tooltip {
+    background-color: #f36f22;
+    padding: 3px 10px;
+    color: #fff;
+    position: fixed;
+    z-index: 2000;
+    font-size: 10px;    
+  }
+  #cedar-tooltip .title {
+    font-size: 15pt;
+    font-weight: bold;
+  }
+  #cedar-tooltip .content {
+    font-size: 10pt;
+  }
+</style>
 
 <h1>Time Example</h1>
 
+<div id="cedar-tooltip" style="display: none"></div>
 <div id="chart"></div>
 
 
@@ -22,10 +40,37 @@ layout: example.hbs
 
     }
   };
+  var tooltip = {
+    "title": "{Year}",
+    "content": "{Injuries} injuries<br/>{Fatalities} fatalities"
+  };
+
   chart.dataset = dataset;
   //chart.dataset.mappings.sort = "DATE";
   chart.show({
     elementId: "#chart",
-  });  
+  }); 
+
+  chart.on('mouseover', function(event,data){
+    console.log("event", event);
+    console.log("data", data);
+
+      var cedartip = document.getElementById('cedar-tooltip');
+      cedartip.style.top = event.pageY + "px";
+      cedartip.style.left = event.pageX + "px";
+      cedartip.style.display = "block";
+      var content = "<span class='title'>" + tooltip.title + "</span><br />";
+      content += "<p class='content'>" + tooltip.content + "</p>";
+
+      cedartip.innerHTML = content.replace( /\{(\w+)\}/g, function replacer(match, $1){
+        return data[$1];
+      } );
+    });
+  chart.on('mouseout', function(event,data){
+      var tooltip = document.getElementById('cedar-tooltip');
+      tooltip.style.top = event.pageY+10 + "px";
+      tooltip.style.left = event.pageX+10 + "px";
+      tooltip.style.display = "none";
+    })
 
 </script>

--- a/site/source/pages/examples/time.hbs
+++ b/site/source/pages/examples/time.hbs
@@ -3,27 +3,10 @@ title: Time Example
 layout: example.hbs
 ---
 
-<style type="text/css">
-  #cedar-tooltip {
-    background-color: #f36f22;
-    padding: 3px 10px;
-    color: #fff;
-    position: fixed;
-    z-index: 2000;
-    font-size: 10px;    
-  }
-  #cedar-tooltip .title {
-    font-size: 15pt;
-    font-weight: bold;
-  }
-  #cedar-tooltip .content {
-    font-size: 10pt;
-  }
-</style>
 
 <h1>Time Example</h1>
 
-<div id="cedar-tooltip" style="display: none"></div>
+<div id="cedar-tooltip" class="cedar-tooltip" style="display: none"></div>
 <div id="chart"></div>
 
 

--- a/site/source/partials/example-bar-data.hbs
+++ b/site/source/partials/example-bar-data.hbs
@@ -6,8 +6,8 @@
   var dataset = {
     "data": features,
     "mappings":{
-      "group": {"field":"ZIP_CODE","label":"ZIP Code"},
-      "count": {"field":"TOTAL_STUD","label":"Total Students"}
+      "x": {"field":"ZIP_CODE","label":"ZIP Code"},
+      "y": {"field":"TOTAL_STUD_SUM","label":"Total Students"}
     }
   };
 

--- a/site/source/partials/example-bar-data.hbs
+++ b/site/source/partials/example-bar-data.hbs
@@ -11,11 +11,34 @@
     }
   };
 
+  var tooltipdata = {
+    "id": "tooltip-data",
+    "title": "{ZIP_CODE}",
+    "content": "{TOTAL_STUD_SUM} Students in {ZIP_CODE}"
+  }
+
   //assign to the chart
   chart.dataset = dataset;
 
   //show the chart
   chart.show({
-    elementId: "#bar-data"
+    elementId: "#chart-data"
   });
+
+  chart.on('mouseout', function(event,data){
+      var cedartip = document.getElementById(tooltipdata.id);
+      cedartip.style.display = "none";
+    })
+  chart.on('mouseover', function(event,data){
+      var cedartip = document.getElementById(tooltipdata.id);
+      cedartip.style.top = event.pageY+100 + "px";
+      cedartip.style.left = event.pageX+20 + "px";
+      cedartip.style.display = "block";
+      var content = "<span class='title'>" + tooltipdata.title + "</span><br />";
+      content += "<p class='content'>" + tooltipdata.content + "</p>";
+
+      cedartip.innerHTML = content.replace( /\{(\w+)\}/g, function replacer(match, $1){
+        return data[$1];
+      } );
+    });
 </script>

--- a/site/source/partials/example-bar-url.hbs
+++ b/site/source/partials/example-bar-url.hbs
@@ -22,7 +22,8 @@
 
   //show the chart
   chart.show({
-    elementId: "#chart-url"
+    elementId: "#chart-url",
+    renderer: "svg"
   });
 
   chart.on('mouseout', function(event,data){

--- a/site/source/partials/example-bar-url.hbs
+++ b/site/source/partials/example-bar-url.hbs
@@ -4,10 +4,18 @@
   //create the dataset w/ mappings
   var dataset = {
     "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+    "query": {
+      "groupByFieldsForStatistics": "ZIP_CODE",
+      "outStatistics": [{
+        "statisticType": "sum", 
+        "onStatisticField": "TOTAL_STUD", 
+        "outStatisticFieldName": "TOTAL_STUD_SUM"
+      }]
+    },
     "mappings":{
       "sort": "TOTAL_STUD_SUM DESC",
-      "group": {"field":"ZIP_CODE","label":"ZIP Code"},
-      "count": {"field":"TOTAL_STUD","label":"Total Students"}
+      "x": {"field":"ZIP_CODE","label":"ZIP Code"},
+      "y": {"field":"TOTAL_STUD_SUM","label":"Total Students"}
     }
   };
 
@@ -31,16 +39,18 @@
       cedartip.style.display = "none";
     })
   chart.on('mouseover', function(event,data){
-      var cedartip = document.getElementById(tooltipurl.id);
-      console.log(event)
-      cedartip.style.top = event.offsetY+100 + "px";
-      cedartip.style.left = event.offsetX+20 + "px";
-      cedartip.style.display = "block";
-      var content = "<span class='title'>" + tooltipurl.title + "</span><br />";
-      content += "<p class='content'>" + tooltipurl.content + "</p>";
-
-      cedartip.innerHTML = content.replace( /\{(\w+)\}/g, function replacer(match, $1){
-        return data[$1];
-      } );
-    });
+    if(data === undefined || data === null) {
+      return;
+    }
+    var cedartip = document.getElementById(tooltipurl.id);
+    cedartip.style.top = event.offsetY + 80 + "px";
+    cedartip.style.left = event.offsetX+30 + "px";
+    cedartip.style.display = "block";
+    var content = "<span class='title'>" + tooltipurl.title + "</span><br />";
+    content += "<p class='content'>" + tooltipurl.content + "</p>";
+    content = content.replace( /\{(\w+)\}/g, function replacer(match, $1){
+      return data[$1];
+    } );
+    document.getElementById(tooltipurl.id).innerHTML = content;
+  });
 </script>

--- a/site/source/partials/example-bar-url.hbs
+++ b/site/source/partials/example-bar-url.hbs
@@ -11,11 +11,35 @@
     }
   };
 
+  var tooltipurl = {
+    "id": "tooltip-url",
+    "title": "{ZIP_CODE}",
+    "content": "{TOTAL_STUD_SUM} Students in {ZIP_CODE}"
+  }
+
   //assign to the chart
   chart.dataset = dataset;
 
   //show the chart
   chart.show({
-    elementId: "#bar-url"
+    elementId: "#chart-url"
   });
+
+  chart.on('mouseout', function(event,data){
+      var cedartip = document.getElementById(tooltipurl.id);
+      cedartip.style.display = "none";
+    })
+  chart.on('mouseover', function(event,data){
+      var cedartip = document.getElementById(tooltipurl.id);
+      console.log(event)
+      cedartip.style.top = event.offsetY+100 + "px";
+      cedartip.style.left = event.offsetX+20 + "px";
+      cedartip.style.display = "block";
+      var content = "<span class='title'>" + tooltipurl.title + "</span><br />";
+      content += "<p class='content'>" + tooltipurl.content + "</p>";
+
+      cedartip.innerHTML = content.replace( /\{(\w+)\}/g, function replacer(match, $1){
+        return data[$1];
+      } );
+    });
 </script>

--- a/site/source/scss/style.scss
+++ b/site/source/scss/style.scss
@@ -1,1 +1,31 @@
 @import '../../../bower_components/bootstrap-sass-official/assets/stylesheets/_bootstrap.scss';
+
+  .cedar-tooltip {
+    background-color: #f36f22;
+    padding: 3px 10px;
+    color: #fff;
+    position: absolute;
+    z-index: 2000;
+    font-size: 10px;    
+  }
+  .cedar-tooltip .title {
+    font-size: 13pt;
+    font-weight: bold;
+  }
+  .cedar-tooltip .content {
+    font-size: 10pt;
+  }
+  /* Add the caret */
+  .cedar-tooltip:after 
+  {
+    content: '';
+    position: absolute;
+    border-style: solid;
+    border-width: 15px 15px 15px 0;
+    border-color: transparent #f36f22;
+    display: block;
+    width: 0;
+    z-index: 1;
+    left: -15px;
+    top: 14px;
+  }  

--- a/src/cedar.js
+++ b/src/cedar.js
@@ -505,9 +505,9 @@ Cedar.prototype._handler = function(evtName) {
       if(registeredHandler.type === evtName){
         //invoke the callback with the data
         if ( item ) {
-          registeredHandler.callback(item.datum.data.attributes);
+          registeredHandler.callback(evt, item.datum.data.attributes);
         } else {
-          registeredHandler.callback();
+          registeredHandler.callback(evt,null);
         }
       }
     });


### PR DESCRIPTION
- Event callbacks now include the `event` for getting mouse location
- Matches style defined by @ddred11 
- Removed extraneous header/footer from example code

Resolves #90
Resolves #44

## Todo

- [ ] More work to do on styling - font sizes need verification. 
- [ ] Move Tooltips into Cedar-core
 - understand CSS for tooltip using `pageX` vs. `offsetX`

![bar_chart___esri_cedar](https://cloud.githubusercontent.com/assets/1218/7900428/c0bf5d7e-0724-11e5-9c32-e04cb062c1cd.png)

![esri_cedar](https://cloud.githubusercontent.com/assets/1218/7900433/09cdadfe-0725-11e5-9520-653e5ce4c5cd.png)

/cc @tomwayson @phlorah