### PR TITLE
fix bug where npm start causes machine to freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed specs to accept &sqlFormat=standard
 - Added missing peer dependencies as dev dependencies for npm3 users
 - use node-sass so ruby is not required to run docs site
+- fix bug where `npm start` causes machine to freeze
 
 ## [0.4.2] - 2016-05-04
 ### Support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added missing peer dependencies as dev dependencies for npm3 users
 - use node-sass so ruby is not required to run docs site
 - fix bug where `npm start` causes machine to freeze
+- remove unused grunt tasks/plugins
 
 ## [0.4.2] - 2016-05-04
 ### Support

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -267,54 +267,14 @@ module.exports = function(grunt) {
 
       },
       src: ['**']
-    },
-
-    // s3: {
-    //   options: {
-    //     key: '<%= aws.key %>',
-    //     secret: '<%= aws.secret %>',
-    //     bucket: '<%= aws.bucket %>',
-    //     access: 'public-read',
-    //     headers: {
-    //       // 1 Year cache policy (1000 * 60 * 60 * 24 * 365)
-    //       'Cache-Control': 'max-age=630720000, public',
-    //       'Expires': new Date(Date.now() + 63072000000).toUTCString()
-    //     }
-    //   },
-    //   upload: {
-    //     upload: [
-    //       {
-    //         src: 'dist/**/*',
-    //         dest: 'esri-leaflet/<%= pkg.version %>/'
-    //       }
-    //     ]
-    //   }
-    // },
-
-    releaseable: {
-      release: {
-        options: {
-          remote: 'upstream',
-          dryRun: grunt.option('dryRun') ? grunt.option('dryRun') : false,
-          silent: false
-        },
-        src: [ 'dist/**/*.js','dist/**/*.map' ]
-      }
     }
   });
-
-  // var awsExists = fs.existsSync(process.env.HOME + '/esri-leaflet-s3.json');
-
-  // if (awsExists) {
-  //   grunt.config.set('aws', grunt.file.readJSON(process.env.HOME + '/esri-leaflet-s3.json'));
-  // }
 
   // Development Tasks
   grunt.registerTask('default', ['docs']);
   grunt.registerTask('build', ['jshint', 'karma:coverage', 'concat', 'uglify', 'copy:specs']);
   grunt.registerTask('test', ['jshint', 'karma:run']);
   grunt.registerTask('publish', ['concat', 'uglify', 'copy:specs']);
-  grunt.registerTask('release', ['releaseable', 's3']);
   grunt.registerTask('test:sauce', ['karma:sauce']);
 
   // Documentation Site Tasks

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,13 +106,6 @@ module.exports = function(grunt) {
       }
     },
 
-    concurrent: {
-      options: {
-        logConcurrentOutput: true
-      },
-      dev: ['watch:scripts', 'karma:watch', 'docs']
-    },
-
     concat: {
       options: {
         sourceMap: true,
@@ -317,7 +310,7 @@ module.exports = function(grunt) {
   // }
 
   // Development Tasks
-  grunt.registerTask('default', ['concurrent:dev']);
+  grunt.registerTask('default', ['docs']);
   grunt.registerTask('build', ['jshint', 'karma:coverage', 'concat', 'uglify', 'copy:specs']);
   grunt.registerTask('test', ['jshint', 'karma:run']);
   grunt.registerTask('publish', ['concat', 'uglify', 'copy:specs']);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "D3"
   ],
   "author": "Esri DC",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/esri/cedar/issues"
   },
@@ -41,8 +41,6 @@
     "grunt-gh-pages": "^0.8.1",
     "grunt-karma": "^0.8.3",
     "grunt-newer": "^0.7.0",
-    "grunt-releaseable": "0.0.12",
-    "grunt-s3": "^0.2.0-alpha.3",
     "grunt-sass": "^1.2.0",
     "highlight.js": "^8.0.0",
     "karma": "^0.12.16",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "browserify": "~8.0.2",
     "chai": "^3.5.0",
     "grunt": "^0.4.2",
-    "grunt-concurrent": "^0.5.0",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-connect": "^0.4.1",
     "grunt-contrib-copy": "^0.5.0",


### PR DESCRIPTION
grunt-concurrent was calling watch tasks and docs, which also called watch
point npm start to grunt docs
remove grunt-concurrent