### PR TITLE
Fixed spec example by also fixing opts.timeout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -174,7 +174,7 @@ module.exports = function(grunt) {
       },
       docs: {
         options: {
-          port: 8081,
+          port: 8082,
           hostname: '0.0.0.0',
           base: './site/build/'
         }

--- a/site/source/pages/examples/spec-inlined.hbs
+++ b/site/source/pages/examples/spec-inlined.hbs
@@ -21,8 +21,6 @@ layout: example.hbs
 
 
 <script>
-  //create a cedar chart
-  var chart = new Cedar();
 
   //create the specification
   var spec ={
@@ -65,9 +63,9 @@ layout: example.hbs
     ],
     "axes": [
       {
-        "type": "x", 
+        "type": "x",
         "scale": "x",
-        "title": "{time.label}", 
+        "title": "{time.label}",
         "properties": {
           "title": {
             "fontSize": {"value": 15},
@@ -88,16 +86,16 @@ layout: example.hbs
         }
       },
       {
-        "type": "y", 
+        "type": "y",
         "scale": "y",
-        "title": "{value.label}", 
+        "title": "{value.label}",
         "ticks": 2,
         "properties": {
           "title": {
             "fontSize": {"value": 15},
             "fill": {"value": "#999"},
             "fontWeight": {"value": "normal"}
-          },          
+          },
           "ticks": {
              "stroke": {"value": "#dbdad9"}
           },
@@ -172,7 +170,7 @@ var chart = new Cedar({"specification":spec});
     elementId: "#chart",
     autolabels: true,
     renderer: "svg"
-  }); 
+  });
 
 
   $(function() {
@@ -181,4 +179,3 @@ var chart = new Cedar({"specification":spec});
     });
   });
 </script>
-

--- a/src/cedar.js
+++ b/src/cedar.js
@@ -103,7 +103,6 @@ var Cedar = function Cedar(options){
 
   var spec;
 
-
   // Internals for holding state
 
   // Cedar configuration such as size
@@ -132,8 +131,8 @@ var Cedar = function Cedar(options){
   this._timeout = undefined;
 
   // override the base timeout
-  if (options.timeout) {
-    this._timeout = options.timeout;
+  if (opts.timeout) {
+    this._timeout = opts.timeout;
   }
 
   // override base URL


### PR DESCRIPTION
[This change](https://github.com/Esri/cedar/commit/eb317701a546d67795e0fe9fd0bb4a1dcc99a034#diff-5c0b5aaebca2221437b2e4cd644fb985R134) accidentially used `options.timeout` instead of `opts.timeout`. 

This caused the "Spec example" to fail because it called an empty constructure `new Cedar()` which would fail because `undefined does not have timeout`

/cc @tomwayson 