### PR TITLE
use SSL always

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,7 +136,7 @@ module.exports = function(grunt) {
   grunt.registerTask('default', ['docs']);
 
   // Documentation Site Tasks
-  grunt.registerTask('docs', ['assemble:dev', 'sass', 'copy', 'connect:docs', 'watch']);
+  grunt.registerTask('docs', ['assemble:dev', 'sass', 'copy', 'imagemin', 'connect:docs', 'watch']);
 
   // Local built to site/build
   grunt.registerTask('docs:build', ['assemble:build', 'sass','copy', 'imagemin']);

--- a/site/source/data/definitions/dc-schools-scatter-chart.json
+++ b/site/source/data/definitions/dc-schools-scatter-chart.json
@@ -1,6 +1,6 @@
 {
   "dataset":{
-    "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+    "url":"https://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
     "query":{},
     "mappings":{
       "x": {"field":"POPULATION_ENROLLED_2008","label":"Enrolment 2008"},

--- a/site/source/data/definitions/home-scatter-chart.json
+++ b/site/source/data/definitions/home-scatter-chart.json
@@ -1,6 +1,6 @@
 {
   "dataset":{
-    "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+    "url":"https://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
     "query":{},
     "mappings":{
       "x": {"field":"POPULATION_ENROLLED_2008","label":"Enrolment 2008"},

--- a/site/source/data/definitions/scatter-events.json
+++ b/site/source/data/definitions/scatter-events.json
@@ -1,6 +1,6 @@
 {
   "dataset":{
-    "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+    "url":"https://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
     "query":{},
     "mappings":{
       "x": {"field":"POPULATION_ENROLLED_2008","label":"Enrolment 2008"},

--- a/site/source/data/examples/chart.json
+++ b/site/source/data/examples/chart.json
@@ -16,11 +16,11 @@
     /**
      * Url to the geoservices rest end-point
      */
-    "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
+    "url":"https://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5",
     /**
      * Query is optional means to filter the dataset
      * Params based on the ArGIS REST API
-     * http://resources.arcgis.com/en/help/arcgis-rest-api/#/Query_Feature_Service_Layer/02r3000000r1000000/
+     * https://resources.arcgis.com/en/help/arcgis-rest-api/#/Query_Feature_Service_Layer/02r3000000r1000000/
      */
     "query": {
       "where": "1=1",

--- a/site/source/data/read-only-charts/dc-schools-scatter-chart.json
+++ b/site/source/data/read-only-charts/dc-schools-scatter-chart.json
@@ -4,7 +4,7 @@
   "data": [
     {
       "name": "iris",
-      "url": "http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5/query?where=1%3D1&returnGeometry=false&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&outFields=*&f=json",
+      "url": "https://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Education_WebMercator/MapServer/5/query?where=1%3D1&returnGeometry=false&returnDistinctValues=false&returnIdsOnly=false&returnCountOnly=false&outFields=*&f=json",
       "format": {
         "property": "features"
       }

--- a/site/source/layouts/documentation.hbs
+++ b/site/source/layouts/documentation.hbs
@@ -6,7 +6,7 @@ layout: page.hbs
   {{# markdown }}
     {{> body }}
   {{/ markdown }}
-  <p><a href="http://github.com/esri/cedar/edit/master/{{page.src}}">Edit this page on GitHub</a></p>
+  <p><a href="https://github.com/esri/cedar/edit/master/{{page.src}}">Edit this page on GitHub</a></p>
 </div>
 
 <div class="col-lg-2">

--- a/site/source/layouts/example.hbs
+++ b/site/source/layouts/example.hbs
@@ -11,7 +11,7 @@ layout: page.hbs
    	  <h2 class="page-header">{{page.title}}</h2>
 	  {{> body }}
 	  <div class="wrap">
-	    <p><a href="http://github.com/esri/cedar/edit/master/{{page.src}}">Edit this sample on GitHub</a></p>
+	    <p><a href="https://github.com/esri/cedar/edit/master/{{page.src}}">Edit this sample on GitHub</a></p>
 	  </div>
 	</div>
 

--- a/site/source/pages/api/create.hbs
+++ b/site/source/pages/api/create.hbs
@@ -56,4 +56,4 @@ The chart will not appear until <a href="{{assets}}api/show.html">`.show()`</a> 
   });
 ```
 
-*&nbsp;You should not need to set the `baseUrl` unless you are using Internet Explorer, which is not able to determine this location automatically, and defaults to using http://esri.github.io/cedar/js as the `baseUrl` when loading chart pre-defined chart specification JSON files. To prevent this behavior in Internet Explorer, set this to the same URL of the folder where you loaded the Cedar script (cedar.js or cedar.min.js). Example: `baseUrl: `./js`
+*&nbsp;You should not need to set the `baseUrl` unless you are using Internet Explorer, which is not able to determine this location automatically, and defaults to using https://esri.github.io/cedar/js as the `baseUrl` when loading chart pre-defined chart specification JSON files. To prevent this behavior in Internet Explorer, set this to the same URL of the folder where you loaded the Cedar script (cedar.js or cedar.min.js). Example: `baseUrl: `./js`

--- a/site/source/pages/api/dataset.hbs
+++ b/site/source/pages/api/dataset.hbs
@@ -19,7 +19,7 @@ Getter/Setter for the <a href="{{assets}}api/json/dataset-json.html">`dataset`</
 <div id='chartDiv'></div>
 
 <script>
-var chart = new Cedar({'specification': 'http://example.org/url_to_specification.json'})
+var chart = new Cedar({'specification': 'https://example.org/url_to_specification.json'})
 
 //create dataset object
 var dataset = {

--- a/site/source/pages/api/index.hbs
+++ b/site/source/pages/api/index.hbs
@@ -15,7 +15,7 @@ Cedar charts are defined by the following ingredients:
 
 - a `Specification` is a JSON document which includes,
  - `inputs` that declare the variables of the chart such as category or value to be summarized
- - `template` is a declarative syntax for chart design using the [Vega](http://trifacta.github.io/vega/) visualization grammar. 
+ - `template` is a declarative syntax for chart design using the [Vega](https://trifacta.github.io/vega/) visualization grammar. 
 - a `dataset` 
  - either `url` link to the ArcGIS Feature Layer; 
  - ...or `values` can be an array of inline features

--- a/site/source/pages/api/json/dataset-json.md
+++ b/site/source/pages/api/json/dataset-json.md
@@ -59,7 +59,7 @@ Since the inputs contain an optional parameter (`group`), the mappings can also 
 ### dataset.query
 Query is optional, but it is also a very useful parameter, as it allows the developer to specify additional Geoservices query parameters, such as a where clause, or bounding box.
 
-All properties of the query object will be converted into query parameters in the calls to fetch the data from the service. Thus, most geoservices [query parameters](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Query_Feature_Service_Layer/02r3000000r1000000/) are supported. 
+All properties of the query object will be converted into query parameters in the calls to fetch the data from the service. Thus, most geoservices [query parameters](https://resources.arcgis.com/en/help/arcgis-rest-api/#/Query_Feature_Service_Layer/02r3000000r1000000/) are supported. 
 
 As a convenience, Cedar will add the correct `geometry` and `spatialRel`  parameters if a bbox is provided. Other geometric relations can be handled by manually configuring the parameters on the query object. 
 

--- a/site/source/pages/backlog/index.hbs
+++ b/site/source/pages/backlog/index.hbs
@@ -39,6 +39,6 @@ layout: page.hbs
 - example showing how to bind to advanced (vega) events
 {{/markdown}}
   <div class="wrap">
-    <p><a href="http://github.com/esri/cedar/edit/master/{{page.src}}">Edit this sample on GitHub</a></p>
+    <p><a href="https://github.com/esri/cedar/edit/master/{{page.src}}">Edit this sample on GitHub</a></p>
   </div>
 </div>

--- a/site/source/pages/examples/bar-map-leaflet-integration.hbs
+++ b/site/source/pages/examples/bar-map-leaflet-integration.hbs
@@ -3,11 +3,11 @@ layout: example.hbs
 ---
 
 <!-- Load Leaflet from CDN-->
-<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
-<script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@0.7.7/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@0.7.7"></script>
 
 <!-- Load Esri Leaflet from CDN -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.4/esri-leaflet.js"></script>
+<script src="https://unpkg.com/esri-leaflet@1.0.4"></script>
 
 <style>
   #map {width:100%;height:400px;}
@@ -73,8 +73,9 @@ layout: example.hbs
   };
 
   L.esri.basemapLayer('Streets').addTo(map);
-  var featureLayer = L.esri.featureLayer('https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0', {
-   pointToLayer: function (geojson, latlng) {
+  var featureLayer = L.esri.featureLayer({
+    url: 'https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0',
+    pointToLayer: function (geojson, latlng) {
       return L.circleMarker(latlng, geojsonMarkerOptions);
     },
   });
@@ -165,8 +166,9 @@ layout: example.hbs
   };
 
   L.esri.basemapLayer('Streets').addTo(map);
-  var featureLayer = L.esri.featureLayer('https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0', {
-   pointToLayer: function (geojson, latlng) {
+  var featureLayer = L.esri.featureLayer({
+    url: 'https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0',
+    pointToLayer: function (geojson, latlng) {
       return L.circleMarker(latlng, geojsonMarkerOptions);
     },
   });

--- a/site/source/pages/examples/bar.hbs
+++ b/site/source/pages/examples/bar.hbs
@@ -4,7 +4,7 @@ layout: example.hbs
 ---
 
 
-<h2>Example<small>&nbsp;{<a href="http://jsfiddle.net/gh/get/jquery/1.11.0/esri/cedar/tree/master/examples/bar">view in JSFiddle</a>}</small></h2>
+<h2>Example<small>&nbsp;{<a href="https://jsfiddle.net/gh/get/jquery/1.11.0/esri/cedar/tree/master/examples/bar">view in JSFiddle</a>}</small></h2>
  <div id="resizable" class="ui-widget-content">
   <div id="chart-url" style="height: 100%"></div>
  </div>

--- a/site/source/pages/examples/complex-map-multiple-chart.hbs
+++ b/site/source/pages/examples/complex-map-multiple-chart.hbs
@@ -36,8 +36,8 @@ amd: true
   }
 </style>
 
-<link rel="stylesheet" href="http://js.arcgis.com/3.12/esri/css/esri.css">
-<script src="http://js.arcgis.com/3.12/"></script>
+<link rel="stylesheet" href="https://js.arcgis.com/3.12/esri/css/esri.css">
+<script src="https://js.arcgis.com/3.12/"></script>
 
 <div id="ex-container">
   <div id="map"></div>
@@ -59,7 +59,7 @@ amd: true
 
     var rend = new SimpleRenderer(defaultSymbol);
 
-    var featureLayer = new FeatureLayer("http://services.arcgis.com/qEmpZrqTBf5yoq5n/arcgis/rest/services/tornadoes/FeatureServer/0",{
+    var featureLayer = new FeatureLayer("https://services.arcgis.com/qEmpZrqTBf5yoq5n/arcgis/rest/services/tornadoes/FeatureServer/0",{
       mode: FeatureLayer.MODE_ONDEMAND,
       outFields: ["*"]
     });
@@ -88,7 +88,7 @@ amd: true
     console.log('featureLayer', featureLayer);
 
     var dataset = {
-      "url":"http://services.arcgis.com/qEmpZrqTBf5yoq5n/arcgis/rest/services/tornadoes/FeatureServer/0",
+      "url":"https://services.arcgis.com/qEmpZrqTBf5yoq5n/arcgis/rest/services/tornadoes/FeatureServer/0",
       "query": {},
       "mappings":{
         "group": {"field":"STATE","label":"State"},
@@ -122,7 +122,7 @@ amd: true
 
     //chart two!
     var scatterset = {
-      "url":"http://services.arcgis.com/qEmpZrqTBf5yoq5n/arcgis/rest/services/tornadoes/FeatureServer/0",
+      "url":"https://services.arcgis.com/qEmpZrqTBf5yoq5n/arcgis/rest/services/tornadoes/FeatureServer/0",
       "query": {
         "groupByFieldsForStatistics": "MONTH",
         "outStatistics": [{

--- a/site/source/pages/examples/dashboard.hbs
+++ b/site/source/pages/examples/dashboard.hbs
@@ -2,11 +2,11 @@
 title: Dashboard
 layout: layout.hbs
 ---
-<link rel="stylesheet" href="http://gridster.net/dist/jquery.gridster.min.css"></link>
-<link rel="stylesheet" href="http://gridster.net/assets/css/style.css"></link>
+<link rel="stylesheet" href="https://gridster.net/dist/jquery.gridster.min.css"></link>
+<link rel="stylesheet" href="https://gridster.net/assets/css/style.css"></link>
 
-<script type="text/javascript" src="http://gridster.net/assets/js/libs/jquery-1.7.2.min.js"></script>
-<script src="http://gridster.net/dist/jquery.gridster.js" type="text/javascript" charset="utf-8"></script>
+<script type="text/javascript" src="https://gridster.net/assets/js/libs/jquery-1.7.2.min.js"></script>
+<script src="https://gridster.net/dist/jquery.gridster.js" type="text/javascript" charset="utf-8"></script>
 <style type="text/css">
 	.gridster { width: 100%;}
 	.widget {
@@ -49,7 +49,7 @@ $(function(){
     });
 
     function webmapUrl(webmapId) {
-		return "http://www.arcgis.com/sharing/rest/content/items/" + webmapId +"/data?f=json";
+		return "https://www.arcgis.com/sharing/rest/content/items/" + webmapId +"/data?f=json";
     }
     function gistUrl(webmapId) {
 		return "https://gist.githubusercontent.com/ajturner/" + webmapId + "/raw/webmap.json";

--- a/site/source/pages/examples/filter-chart-by-bbox.hbs
+++ b/site/source/pages/examples/filter-chart-by-bbox.hbs
@@ -14,8 +14,8 @@ amd: true
   }
 </style>
 
-<link rel="stylesheet" href="http://js.arcgis.com/3.12/esri/css/esri.css">
-<script src="http://js.arcgis.com/3.12/"></script>
+<link rel="stylesheet" href="https://js.arcgis.com/3.12/esri/css/esri.css">
+<script src="https://js.arcgis.com/3.12/"></script>
 
 {{#markdown}}
 
@@ -45,7 +45,7 @@ This example shows how to filter the charted data based on a bounding box (bbox)
 
     var rend = new SimpleRenderer(defaultSymbol);
 
-    var featureLayer = new FeatureLayer("http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",{
+    var featureLayer = new FeatureLayer("https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",{
       mode: FeatureLayer.SNAPSHOT,
       outFields: ["*"]
     });
@@ -73,7 +73,7 @@ This example shows how to filter the charted data based on a bounding box (bbox)
     map.addLayer(featureLayer);
     
     var dataset = {
-      "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+      "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
       "query": {
         "groupByFieldsForStatistics": "state",
         "outStatistics": [{
@@ -131,7 +131,7 @@ This example shows how to filter the charted data based on a bounding box (bbox)
 
     var rend = new SimpleRenderer(defaultSymbol);
 
-    var featureLayer = new FeatureLayer("http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",{
+    var featureLayer = new FeatureLayer("https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",{
       mode: FeatureLayer.SNAPSHOT,
       outFields: ["*"]
     });
@@ -159,7 +159,7 @@ This example shows how to filter the charted data based on a bounding box (bbox)
     map.addLayer(featureLayer);
     
     var dataset = {
-      "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+      "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
       "query": {
         "groupByFieldsForStatistics": "state",
         "outStatistics": [{

--- a/site/source/pages/examples/filter-chart-by-map-extent.hbs
+++ b/site/source/pages/examples/filter-chart-by-map-extent.hbs
@@ -14,8 +14,8 @@ amd: true
   }
 </style>
 
-<link rel="stylesheet" href="http://js.arcgis.com/3.12/esri/css/esri.css">
-<script src="http://js.arcgis.com/3.12/"></script>
+<link rel="stylesheet" href="https://js.arcgis.com/3.12/esri/css/esri.css">
+<script src="https://js.arcgis.com/3.12/"></script>
 
 
 <h1>Filter Chart by Geometry</h1>
@@ -38,7 +38,7 @@ amd: true
 
     var rend = new SimpleRenderer(defaultSymbol);
 
-    var featureLayer = new FeatureLayer("http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",{
+    var featureLayer = new FeatureLayer("https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",{
       mode: FeatureLayer.SNAPSHOT,
       outFields: ["*"]
     });
@@ -66,7 +66,7 @@ amd: true
     map.addLayer(featureLayer);
     
     var dataset = {
-      "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+      "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
       "query": {
         "groupByFieldsForStatistics": "state",
         "outStatistics": [{
@@ -123,7 +123,7 @@ amd: true
 
     var rend = new SimpleRenderer(defaultSymbol);
 
-    var featureLayer = new FeatureLayer("http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",{
+    var featureLayer = new FeatureLayer("https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",{
       mode: FeatureLayer.SNAPSHOT,
       outFields: ["*"]
     });
@@ -151,7 +151,7 @@ amd: true
     map.addLayer(featureLayer);
     
     var dataset = {
-      "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+      "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
       "query": {
         "groupByFieldsForStatistics": "state",
         "outStatistics": [{

--- a/site/source/pages/examples/grouped.hbs
+++ b/site/source/pages/examples/grouped.hbs
@@ -38,7 +38,7 @@ var chart2 = new Cedar({
 		"content": "{MaleVets2010} Male Vets | {FemaleVets2010} Female Vets"
 	},
 	"dataset":{
-	  "url": "http://maps7.arcgisonline.com/arcgis/rest/services/Veterans_by_Gender/MapServer/1",
+	  "url": "https://maps7.arcgisonline.com/arcgis/rest/services/Veterans_by_Gender/MapServer/1",
 	  "mappings":{
 	    "x": {"field":["attributes.MaleVets2010", "attributes.FemaleVets2010"],"label":"Veterans by Gender"},
 	    "group":{"field":"STATE_NAME","label":"State"}
@@ -82,7 +82,7 @@ chart2.show({
     	"content": "{MaleVets2010} Male Vets | {FemaleVets2010} Female Vets"
     },
     "dataset":{
-	  "url": "http://maps7.arcgisonline.com/arcgis/rest/services/Veterans_by_Gender/MapServer/1",
+	  "url": "https://maps7.arcgisonline.com/arcgis/rest/services/Veterans_by_Gender/MapServer/1",
       "mappings":{
         "x": {"field":["attributes.MaleVets2010", "attributes.FemaleVets2010"],"label":"Veterans by Gender"},
         "group":{"field":"STATE_NAME","label":"State"}

--- a/site/source/pages/examples/map-to-chart-interaction.hbs
+++ b/site/source/pages/examples/map-to-chart-interaction.hbs
@@ -4,8 +4,8 @@ layout: example.hbs
 amd: true
 ---
 
-<link rel="stylesheet" href="http://js.arcgis.com/3.12/esri/css/esri.css">
-<script src="http://js.arcgis.com/3.12/"></script>
+<link rel="stylesheet" href="https://js.arcgis.com/3.12/esri/css/esri.css">
+<script src="https://js.arcgis.com/3.12/"></script>
 
 
 <h1>Map to Chart Interaction</h1>

--- a/site/source/pages/examples/spec-inlined.hbs
+++ b/site/source/pages/examples/spec-inlined.hbs
@@ -7,8 +7,8 @@ layout: example.hbs
 <h1></h1>
 
   <link rel="stylesheet" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
-  <script src="//code.jquery.com/jquery-1.10.2.js"></script>
-  <script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
+  <script src="https://code.jquery.com/jquery-1.10.2.js"></script>
+  <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
   <style>
     #examples { height: 1800px; }
     #resizable { width: 750px; height: 550px; padding: 0.5em; }
@@ -151,7 +151,7 @@ layout: example.hbs
 var chart = new Cedar({"specification":spec});
 
   var dataset = {
-    "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+    "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
     "mappings":{
       "time": {"field":"Date", "label": "Time"},
       "value": {"field":"Injuries", "label": "Injuries"},

--- a/site/source/pages/examples/style-overrides.hbs
+++ b/site/source/pages/examples/style-overrides.hbs
@@ -50,7 +50,7 @@ layout: example.hbs
   var barChart = new Cedar({"type": "bar"});
   //create the dataset w/ mappings
   var dataset = {
-    "url":"http://services.arcgis.com/pmcEyn9tLWCoX7Dm/arcgis/rest/services/CA_Hospitals/FeatureServer/0",
+    "url":"https://services.arcgis.com/pmcEyn9tLWCoX7Dm/arcgis/rest/services/CA_Hospitals/FeatureServer/0",
     "query": {
       "groupByFieldsForStatistics": "Hospital_Ownership",
       "outStatistics": [{

--- a/site/source/pages/examples/time-aggregation.hbs
+++ b/site/source/pages/examples/time-aggregation.hbs
@@ -12,7 +12,7 @@ layout: example.hbs
 <pre class="prettyprint">var chart = new Cedar({"type":"bar"});
 
 var dataset = {
-  "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+  "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
   "query": {
     "groupByFieldsForStatistics": "EXTRACT(YEAR from Date)",
     "outStatistics": [{
@@ -47,7 +47,7 @@ chart.show({
 var chart = new Cedar({"type":"bar"});
 
 var dataset = {
-  "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+  "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
   "query": {
     "groupByFieldsForStatistics": "EXTRACT(YEAR from Date)",
     "outStatistics": [{

--- a/site/source/pages/examples/time-trendline.hbs
+++ b/site/source/pages/examples/time-trendline.hbs
@@ -14,7 +14,7 @@ layout: example.hbs
   var chart = new Cedar({"type":"time-trendline"});
 
   var dataset = {
-    "url":"http://services6.arcgis.com/Y3k193RFrcECJ8xA/arcgis/rest/services/Observed_Precipitation/FeatureServer/0",
+    "url":"https://services6.arcgis.com/Y3k193RFrcECJ8xA/arcgis/rest/services/Observed_Precipitation/FeatureServer/0",
     "query" : {
       "where" : "year > 2000"
     },
@@ -60,7 +60,7 @@ layout: example.hbs
   var chart = new Cedar({"type":"time-trendline"});
 
   var dataset = {
-    "url":"http://services6.arcgis.com/Y3k193RFrcECJ8xA/arcgis/rest/services/Observed_Precipitation/FeatureServer/0",
+    "url":"https://services6.arcgis.com/Y3k193RFrcECJ8xA/arcgis/rest/services/Observed_Precipitation/FeatureServer/0",
     "mappings":{
       "time": {"field":"year", "label": "Year"},
       "value": {"field":"annual", "label": "Total Precipitation"},
@@ -130,7 +130,7 @@ layout: example.hbs
   var chart = new Cedar({"type":"time-trendline"});
 
   var dataset = {
-    "url":"http://services6.arcgis.com/Y3k193RFrcECJ8xA/arcgis/rest/services/Observed_Precipitation/FeatureServer/0",
+    "url":"https://services6.arcgis.com/Y3k193RFrcECJ8xA/arcgis/rest/services/Observed_Precipitation/FeatureServer/0",
     "query" : {
       "where" : "year > 2000"
     },
@@ -167,7 +167,7 @@ layout: example.hbs
   var chart_override = new Cedar({"type":"time-trendline"});
 
   var dataset = {
-    "url":"http://services6.arcgis.com/Y3k193RFrcECJ8xA/arcgis/rest/services/Observed_Precipitation/FeatureServer/0",
+    "url":"https://services6.arcgis.com/Y3k193RFrcECJ8xA/arcgis/rest/services/Observed_Precipitation/FeatureServer/0",
     "mappings":{
       "time": {"field":"year", "label": "Year"},
       "value": {"field":"annual", "label": "Total Precipitation"},

--- a/site/source/pages/examples/time.hbs
+++ b/site/source/pages/examples/time.hbs
@@ -12,7 +12,7 @@ layout: example.hbs
 <pre class="prettyprint">var chart = new Cedar({"type":"time"});
 
 var dataset = {
-  "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+  "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
   "mappings":{
     "x": {"field":"Date", "label": "Date"},
     "y": {"field":"Injuries", "label": "Injuries"},
@@ -39,7 +39,7 @@ chart.show({
   var chart = new Cedar({"type":"time"});
 
   var dataset = {
-    "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+    "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
     "mappings":{
       "time": {"field":"Date", "label": "Date"},
       "value": {"field":"Injuries", "label": "Injuries"},

--- a/site/source/pages/examples/vega.hbs
+++ b/site/source/pages/examples/vega.hbs
@@ -30,7 +30,7 @@ layout: example.hbs
       "data": [
         {
           "name": "dummy",
-          "url": "http://example.org",
+          "url": "https://example.org",
           "format": {
             "type": "json",
             "property": "features"

--- a/site/source/pages/index.hbs
+++ b/site/source/pages/index.hbs
@@ -10,9 +10,9 @@ layout: page.hbs
   <div class="col-lg-9">
     <h2 class="">{{page.title}}</h2>
   	<p>
-  	Cedar is a Javascript library for crafting visualizations, in particular with the <a href="http://geoservices.github.io/">GeoServices API</a> from ArcGIS. This includes common chart types such as bar charts, line charts, scatterplots, as well as custom graphics designed with <a href="http://vega.github.io">Vega grammar</a>. Built on D3.js - Cedar is extensible and interactive.
+  	Cedar is a Javascript library for crafting visualizations, in particular with the <a href="https://geoservices.github.io/">GeoServices API</a> from ArcGIS. This includes common chart types such as bar charts, line charts, scatterplots, as well as custom graphics designed with <a href="https://vega.github.io">Vega grammar</a>. Built on D3.js - Cedar is extensible and interactive.
   	</p>
-  	<p>Cedar is open-source under the Apache license. Visit the <a href="http://github.com/esri/cedar">Esri Github</a> repository to learn more and contribute.</p>
+  	<p>Cedar is open-source under the Apache license. Visit the <a href="https://github.com/esri/cedar">Esri Github</a> repository to learn more and contribute.</p>
   </div>
 
 </div>

--- a/site/source/pages/tutorial/index.hbs
+++ b/site/source/pages/tutorial/index.hbs
@@ -16,7 +16,7 @@ First, we create a new Cedar object and specify we want a bar chart. In this exa
 Now we need to define the data. We can either use an array of data that we have calculated in our code, or we can refer to an ArcGIS GeoServices layer. For the GeoServices Layer, Cedar will make the HTTP API calls to request data for us.
 
 <pre class="prettyprint">chart.dataset = {
-  "url":"http://server.arcgisonline.com/arcgis/rest/services/Demographics/USA_Population_Density/MapServer/4"
+  "url":"https://server.arcgisonline.com/arcgis/rest/services/Demographics/USA_Population_Density/MapServer/4"
 };
 </pre>
 
@@ -45,7 +45,7 @@ We could also pull all this into a single set of commands with some additional o
 <pre class="prettyprint">chart = new Cedar({
   "type": "bar",
   "dataset": {
-    "url":"http://maps7.arcgisonline.com/arcgis/rest/services/Veterans_Proportion_From_Population/MapServer/0",
+    "url":"https://maps7.arcgisonline.com/arcgis/rest/services/Veterans_Proportion_From_Population/MapServer/0",
     "query": {
       "orderByFields": "TotPop DESC"
     },
@@ -65,7 +65,7 @@ We could also pull all this into a single set of commands with some additional o
 var chart = new Cedar({
   "type": "bar",
   "dataset": {
-    "url":"http://maps7.arcgisonline.com/arcgis/rest/services/Veterans_Proportion_From_Population/MapServer/0",
+    "url":"https://maps7.arcgisonline.com/arcgis/rest/services/Veterans_Proportion_From_Population/MapServer/0",
     "query": {
       "orderByFields": "TotPop DESC"
     },

--- a/site/source/partials/example-code-header.hbs
+++ b/site/source/partials/example-code-header.hbs
@@ -5,8 +5,8 @@
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load D3 and vega -->
-  <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
-  <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/vega/2.5.2/vega.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vega/2.5.2/vega.min.js"></script>
 
   <!-- Load Cedar -->
   <script type="text/javascript" src="cedar.js"></script>

--- a/site/source/partials/example-map-chart.hbs
+++ b/site/source/partials/example-map-chart.hbs
@@ -15,7 +15,7 @@
 		    },
 		    {
 		      "name": "area",
-		      "url": "http://opendata.dc.gov/datasets/4919ca2fa0894de18e4752a5e16ca683_22.geojson",
+		      "url": "https://opendata.dc.gov/datasets/4919ca2fa0894de18e4752a5e16ca683_22.geojson",
 		      "format": {"type": "json","property": "features"},
 		      "transform": [
 		        {
@@ -63,7 +63,7 @@
   var chart = new Cedar({"specification":spec});
   var dataset = {
   	// placeholder until Cedar can just accept GeoJSON
-    "url":"http://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
+    "url":"https://services.arcgis.com/bkrWlSKcjUDFDtgw/arcgis/rest/services/It's_a_Tornado_Map/FeatureServer/0",
     "mappings":{
         "value": {"field":"DCGISUTC_WardUTC_PV_P", "label": "Possible Vegetation %"}
     }

--- a/site/source/partials/example-time-dots.hbs
+++ b/site/source/partials/example-time-dots.hbs
@@ -3,7 +3,7 @@
   var chart = new Cedar({"specification":"{{assets}}data/templates/time-dots.json"});
 
   var dataset = {
-    "url":"http://maps2.dcgis.dc.gov/dcgis/rest/services/FEEDS/CDW_Feeds/MapServer/8",
+    "url":"https://maps2.dcgis.dc.gov/dcgis/rest/services/FEEDS/CDW_Feeds/MapServer/8",
     "mappings":{
       "time":   {"field":"REPORTDATETIME"},
       "aspect": {"field":"OFFENSE"},

--- a/site/source/partials/header.hbs
+++ b/site/source/partials/header.hbs
@@ -40,15 +40,15 @@
         packages: [
           {
             name: 'd3',
-            location: 'http://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5',
+            location: 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5',
             main: 'd3.min'
           }, {
             name: 'topojson',
-            location: 'http://cdnjs.cloudflare.com/ajax/libs/topojson/1.6.19',
+            location: 'https://cdnjs.cloudflare.com/ajax/libs/topojson/1.6.19',
             main: 'topojson.min'
           }, {
             name: 'vega',
-            location: 'http://vega.github.io/vega/',
+            location: 'https://vega.github.io/vega/',
             main: 'vega.min'
           }, {
             name: 'cedar',


### PR DESCRIPTION
* bumped a whole lotta links to use `https` instead of `http`.  this fixes lots of samples that are broken when loaded over https (as i noticed when i followed an inbound google link)
  * https://esri.github.io/cedar/examples/map-to-chart-interaction.html
  * https://esri.github.io/cedar/examples/time.html
  * https://esri.github.io/cedar/examples/filter-chart-by-map-extent.html
  * https://esri.github.io/cedar/examples/spec-url.html

* bumped the leaflet sample to use a more modern 0.7.x version that supports SSL
* made sure that images are copied to the build folder when folks call `npm start`

the [dashboard](https://esri.github.io/cedar/examples/dashboard.html) sample is still broken (because the .css fails to load either way), but since there's no link in the TOC, i felt like it was approriate to just leave that one be.

