### PR TITLE
add karma-rollup-pluing to run unit tests off source files

### DIFF
--- a/karma.dev.conf.js
+++ b/karma.dev.conf.js
@@ -1,0 +1,52 @@
+// import base configuration
+var base = require('./karma.conf');
+var json = require('rollup-plugin-json');
+var buble =require('rollup-plugin-buble');
+
+
+module.exports = function(config) {
+  // apply base settings
+  base(config);
+  // then override
+  config.set({
+    // list of files / patterns to load in the browser
+    files: [
+      'node_modules/d3/d3.js',
+      'node_modules/vega/vega.js',
+      'test/spec/**/*.spec.js',
+      { pattern: 'src/utils/**/*.js', included: false, served: false },
+      { pattern: 'src/charts/**/*.json', included: false, served: true },
+      'src/cedar.js',
+    ],
+
+    preprocessors: {
+     'src/cedar.js': ['rollup']
+    },
+
+    reporters: ['mocha'],
+
+    // Configure the plugins
+    rollupPreprocessor: {
+      // rollup settings. See Rollup documentation
+      moduleName: 'Cedar',
+      // format: 'umd',
+      format: 'iife',
+      external: ['d3', 'vega'],
+      plugins: [json(), buble()],
+      globals: {
+        'arcgis-cedar': 'Cedar',
+        'd3': 'd3',
+        'vega': 'vg'
+      },
+      // will help to prevent conflicts between different tests entries
+      sourceMap: 'inline'
+    },
+
+    mochaReporter: {
+      showDiff: true
+    },
+
+    // re-run when files are changed
+    singleRun: false
+  });
+};

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "karma-mocha": "^1.2.0",
     "karma-mocha-reporter": "^2.2.0",
     "karma-phantomjs-launcher": "^1.0.2",
+    "karma-rollup-plugin": "^0.2.4",
     "karma-safari-launcher": "^1.0.0",
     "karma-sauce-launcher": "^0.2.14",
     "load-grunt-tasks": "^0.4.0",

--- a/test/spec/cedar.spec.js
+++ b/test/spec/cedar.spec.js
@@ -16,7 +16,7 @@ describe('Cedar', function () {
     requests = [];
   });
 
-  describe('constructor', function () {
+  describe('new', function () {
     var fakeDefinition, fakeSpec;
     beforeEach(function() {
       fakeDefinition = {


### PR DESCRIPTION
karma.dev.conf.js will continuously build ES6 source usigng rollup and buble and run tests as you code
this new config also use the mocha reporter for better visual diffs of deeply nested properties of actual and expected objects
for now did not change existing testing scripts/configurations, but may eventually want to (esp for coverage)

to run try: `node_modules/.bin/karma start karma.dev.conf.js`
