### PR TITLE
fixed multiple colors for pie chart

### DIFF
--- a/src/charts/pie.json
+++ b/src/charts/pie.json
@@ -32,7 +32,7 @@
         "type": "ordinal",
         "domain": {
           "data": "table",
-          "field": "attributes.{y.field}"
+          "field": "attributes.{label.field}"
         },
         "range": "category10"
       }
@@ -51,10 +51,11 @@
             "stroke": {"value": "#fff"}
           },
           "update": {
-            "fill": {"value": "#0079c1"}
+            "fill": {"scale": "color", "field": "attributes.{label.field}"},
+            "fillOpacity": {"value": 1}
           },
           "hover": {
-            "fill": {"value": "#29b6ea"}
+            "fillOpacity": {"value": 0.8}
           }
         }
       },


### PR DESCRIPTION
<img width="517" alt="screen shot 2017-02-01 at 10 21 19 am" src="https://cloud.githubusercontent.com/assets/7990129/22520237/60f2e538-e868-11e6-8433-a461abdd49d6.png">

This is currently using 'category10' like the rest of the library but there are other color schemes that can be used. Will need to test to see if that can be overridden with style overrides yet. 