### PR TITLE
fix spec-defaults sample and hide others pointing at dead service

### DIFF
--- a/site/source/pages/examples/spec-defaults.hbs
+++ b/site/source/pages/examples/spec-defaults.hbs
@@ -11,7 +11,7 @@ layout: example.hbs
 The specification can provide default values for non-required inputs. In this example, the `color` input is optional and defaults to `steelblue`.
 In the dataset, we specify `color:orange`, thus the chart is orange.
 
-Clicking the Clear Color button will remote color from the mappings, and then the default of `steelblue` will be used. 
+Clicking the Clear Color button will remote color from the mappings, and then the default of `steelblue` will be used.
 
 You can also provide a color (name or #RRGGBB) in the input box and use the Add Color button, which will add it to the mappings and update the chart.
 
@@ -22,7 +22,7 @@ You can also provide a color (name or #RRGGBB) in the input box and use the Add 
   <div class="col-lg-4">
     <h3>Controls</h3>
     <form>
-     
+
       <div class="form-group">
         <label for="color">Color</label>
         <input type="text" id="color" value="green">
@@ -31,11 +31,11 @@ You can also provide a color (name or #RRGGBB) in the input box and use the Add 
       <button id="setColor" class="btn btn-default"  type="button">Add Color</button>
     </form>
   </div>
-  
+
   <div class="col-lg-8">
     <h3>Mappings</h3>
     <pre id="mappings">
-      
+
     </pre>
   </div>
 </div>
@@ -62,7 +62,22 @@ You can also provide a color (name or #RRGGBB) in the input box and use the Add 
       {
         "type": "x",
         "scale": "x",
-        "title": "X-Axis"
+        "title": "X-Axis",
+        "properties": {
+          "labels" : {
+            "angle": {
+              "value": 45
+            }
+          }
+        }
+      },
+      {
+        "type": "y",
+        "scale": "y",
+        "title": "Y-Axis",
+        "properties": {
+          "labels" : {}
+        }
       }
     ],
     "data": [
@@ -150,8 +165,6 @@ You can also provide a color (name or #RRGGBB) in the input box and use the Add 
 
     }
   };
-
-
 
   //assign to the chart
   chart.dataset = dataset;

--- a/site/source/partials/sidebar-examples.hbs
+++ b/site/source/partials/sidebar-examples.hbs
@@ -14,7 +14,7 @@
       <li><a href="{{assets}}examples/sparkline.html">Sparkline</a></li>
       <li><a href="{{assets}}examples/time.html">Timeline</a></li>
       <li><a href="{{assets}}examples/time-aggregation.html">Time Aggregation</a></li>
-      <li><a href="{{assets}}examples/time-dots.html">Time facets</a></li>
+      <!--li><a href="{{assets}}examples/time-dots.html">Time facets</a></li-->
       <li><a href="{{assets}}examples/time-trendline.html">Time with Trendline</a></li>
       <li><a href="{{assets}}examples/map.html">Map Chart</a></li>
     </ul>
@@ -54,7 +54,7 @@
   <h5>Using Specifications</h5>
   <nav>
     <ul>
-      <li><a href="{{assets}}examples/spec-url.html">Specification URL</a></li>
+      <!--li><a href="{{assets}}examples/spec-url.html">Specification URL</a></li-->
       <li><a href="{{assets}}examples/spec-inlined.html">Inline Specification</a></li>
       <li><a href="{{assets}}examples/vega.html">Vega Specification</a></li>
       <li><a href="{{assets}}examples/spec-defaults.html">Defaults</a></li>
@@ -70,8 +70,4 @@
     </ul>
   </nav>
   -->
-
-
-
-
 </aside>


### PR DESCRIPTION
resolves #268 (again) 

for some reason it was necessary to supply `properties.labels` in 'spec-defaults' to get the bar chart to display.

as for the other two broken samples, they're pointing at a service which has been [unpublished](https://maps2.dcgis.dc.gov/dcgis/rest/services/FEEDS/CDW_Feedds/MapServer/8), so i just hid them from the TOC because i couldn't be bothered to try and understand their corresponding custom specification without being able to look at the reference data. 

i'll wait for a 👍  from someone else before merging/deploying this cause its a pretty crap PR.