### PR TITLE
fix invalid check for x/y chart types when generating spec

### DIFF
--- a/packages/cedar-amcharts/src/render/render.ts
+++ b/packages/cedar-amcharts/src/render/render.ts
@@ -56,8 +56,8 @@ export function fillInSpec(spec: any, config: any) {
           graph.newStack = true
         }
 
-        // Only clone scatterplots
-        if (!!graphSpec.xField && !!series.category && !!series.value) {
+        // x/y types (scatter, bubble)
+        if (spec.type === 'xy' && !!series.category && !!series.value) {
           graph.xField = series.category.field
           graph.yField = series.value.field
 


### PR DESCRIPTION
previously cloning via deepMerge converted `null` to `{}`
so checking on `!!graphSpec.xField` worked, but that really was more of an accident
now this checks for `spec.type === 'xy'`
