### PR TITLE
use @esri scoped package names

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "npmClient": "yarn",
-  "version": "0.0.0"
+  "version": "1.0.0-beta"
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "build": "lerna run build --scope cedar-amcharts && lerna run build --scope cedar",
-    "build:prod": "lerna run build:prod --scope cedar-amcharts && lerna run build:prod --scope cedar",
+    "build": "lerna run build --scope @esri/cedar-amcharts && lerna run build --scope @esri/cedar",
+    "build:prod": "lerna run build:prod --scope @esri/cedar-amcharts && lerna run build:prod --@esri/scope cedar",
     "build:watch": "onchange -v 'packages/*/src/**/*.ts' -- npm run build",
     "postinstall": "lerna bootstrap",
     "start": "npm run build && npm run build:watch",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "build": "lerna run build --scope @esri/cedar-amcharts && lerna run build --scope @esri/cedar",
     "build:prod": "lerna run build:prod --scope @esri/cedar-amcharts && lerna run build:prod --@esri/scope cedar",
     "build:watch": "onchange -v 'packages/*/src/**/*.ts' -- npm run build",
+    "reset": "lerna run clean:deps && lerna bootstrap",
     "postinstall": "lerna bootstrap",
     "start": "npm run build && npm run build:watch",
     "test": "lerna run test"

--- a/packages/cedar-amcharts/package.json
+++ b/packages/cedar-amcharts/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cedar-amcharts",
-  "version": "1.0.1-beta",
+  "name": "@esri/cedar-amcharts",
+  "version": "1.0.0-beta",
   "description": "Cedars amcharts engine",
   "main": "dist/umd/cedar-amcharts.js",
   "browser": "dist/umd/cedar-amcharts.js",

--- a/packages/cedar-amcharts/package.json
+++ b/packages/cedar-amcharts/package.json
@@ -8,6 +8,7 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "scripts": {
+    "clean:deps": "rimraf node_modules",
     "clean:dist": "rimraf ./dist && mkdir dist",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "lint:fix": "tslint --fix",

--- a/packages/cedar/package.json
+++ b/packages/cedar/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cedar",
+  "name": "@esri/cedar",
   "version": "1.0.0-beta",
   "description": "Visualization framework for the ArcGIS Platform",
   "main": "dist/umd/cedar.js",
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "amcharts3": "amcharts/amcharts3",
-    "cedar-amcharts": "^1.0.1-beta"
+    "@esri/cedar-amcharts": "^1.0.0-beta"
   },
   "devDependencies": {
     "@types/jest": "20.0.2",

--- a/packages/cedar/package.json
+++ b/packages/cedar/package.json
@@ -8,6 +8,7 @@
   "js:next": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "scripts": {
+    "clean:deps": "rimraf node_modules",
     "clean:dist": "rimraf ./dist && mkdir dist",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "lint:fix": "tslint --fix",

--- a/packages/cedar/src/index.ts
+++ b/packages/cedar/src/index.ts
@@ -1,4 +1,4 @@
-import { cedarAmCharts, deepMerge } from 'cedar-amcharts'
+import { cedarAmCharts, deepMerge } from '@esri/cedar-amcharts'
 import { flattenFeatures } from './flatten/flatten'
 import { getData } from './query/query'
 import { createFeatureServiceRequest } from './query/url'

--- a/packages/cedar/src/query/url.ts
+++ b/packages/cedar/src/query/url.ts
@@ -1,4 +1,4 @@
-import { deepMerge } from 'cedar-amcharts'
+import { deepMerge } from '@esri/cedar-amcharts'
 
 export function defaultQuery() {
   return {


### PR DESCRIPTION
This addresses the package name portion of #279 

The global/constructor naming portion will come in a subsequent PR.

After merging/pulling this you will need to re-run `lerna bootstrap`.