### PR TITLE
support datasets w/ inline data

### DIFF
--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -64,9 +64,6 @@ export default class Chart {
   public get data(): any[] {
     return this._data
   }
-  public set data(data: any[]) {
-    this._data = deepMerge([], data)
-  }
 
   // Chart Specification
   public get chartSpecification(): any {
@@ -85,8 +82,7 @@ export default class Chart {
     this._cedarSpecification = clone(spec)
   }
 
-  // TODO: rename to queryData() or query()?
-  public getData() {
+  public queryData() {
     const names = []
     const requests = []
     const responseHash = {}
@@ -112,7 +108,7 @@ export default class Chart {
     })
   }
 
-  public render(datasetsData: {}) {
+  public updateData(datasetsData: {}) {
     const featureSets = []
     const joinKeys = []
     // TODO: remove transformFucntions here and from flattenFeatures
@@ -133,14 +129,20 @@ export default class Chart {
       }
     })
 
-    this.data = flattenFeatures(featureSets, joinKeys, transformFunctions)
+    this._data = flattenFeatures(featureSets, joinKeys, transformFunctions)
+    // TODO: what shoudl this return?
+  }
+
+  public render() {
     cedarAmCharts(this._container, this.cedarSpecification, this.data)
+    // TODO: what should this return?
   }
 
   public show() {
-    return this.getData()
+    return this.queryData()
     .then((response) => {
-      this.render(response)
+      this.updateData(response)
+      this.render()
     })
   }
 }

--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -85,44 +85,62 @@ export default class Chart {
     this._cedarSpecification = clone(spec)
   }
 
+  // TODO: rename to queryData() or query()?
   public getData() {
+    const names = []
     const requests = []
-    const joinKeys = []
-    const transformFunctions = []
+    const responseHash = {}
 
-    if (!!this.datasets && !!this.series) {
+    if (this.datasets) {
       this.datasets.forEach((dataset, i) => {
-        requests.push(getData(createFeatureServiceRequest(dataset)))
-        if (!dataset.merge) {
-          joinKeys.push(this.series[i].category.field)
+        // only query datasets that don't have inline data
+        if (!dataset.data) {
+          // TODO: make name required on datasets, or required if > 1 dataset?
+          names.push(dataset.name || `dataset${i}`)
+          requests.push(getData(createFeatureServiceRequest(dataset)))
         }
       })
-      //
-      // for (const series of this.series) {
-      //   joinKeys.push(series.category.field)
-      // }
     }
     return Promise.all(requests)
-      .then((responses) => {
-        return Promise.resolve({
-          responses,
-          joinKeys,
-          transformFunctions
-        })
-      }, (err) => {
-        return Promise.reject(err)
+    .then((responses) => {
+      responses.forEach((response, i) => {
+        responseHash[names[i]] = responses[i]
       })
+      return Promise.resolve(responseHash)
+    }, (err) => {
+      return Promise.reject(err)
+    })
   }
 
-  public render(result: any) {
-    this.data = flattenFeatures(result.responses, result.joinKeys, result.transformFunctions)
+  public render(datasetsData: {}) {
+    const featureSets = []
+    const joinKeys = []
+    // TODO: remove transformFucntions here and from flattenFeatures
+    const transformFunctions = []
+
+    // get array of featureSets from datasets data or datasetsData
+    this.datasets.forEach((dataset, i) => {
+      // TODO: make name required on datasets, or required if > 1 dataset?
+      const name = dataset.name || `dataset${i}`
+      // if dataset doesn't have inline data use data that was passed in
+      const featureSet = dataset.data || datasetsData[name]
+      if (featureSet) {
+        featureSets.push(featureSet)
+      }
+      // TODO: this is broken, there is not a 1:1 relationship between datasets/series
+      if (!dataset.merge) {
+        joinKeys.push(this.series[i].category.field)
+      }
+    })
+
+    this.data = flattenFeatures(featureSets, joinKeys, transformFunctions)
     cedarAmCharts(this._container, this.cedarSpecification, this.data)
   }
 
   public show() {
     return this.getData()
-      .then((response) => {
-        this.render(response)
-      })
+    .then((response) => {
+      this.render(response)
+    })
   }
 }

--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -130,19 +130,18 @@ export default class Chart {
     })
 
     this._data = flattenFeatures(featureSets, joinKeys, transformFunctions)
-    // TODO: what shoudl this return?
+    return this
   }
 
   public render() {
     cedarAmCharts(this._container, this.cedarSpecification, this.data)
-    // TODO: what should this return?
+    return this
   }
 
   public show() {
     return this.queryData()
     .then((response) => {
-      this.updateData(response)
-      this.render()
+      return this.updateData(response).render()
     })
   }
 }


### PR DESCRIPTION
resolves #296

`getData` now:
- only operates on datasets w/o `.data`
- returns a hash of query responses using the `dataset.name` (for now defaulting to `dataset${i}` as the name if `dataset` doesn't have one) as the key and the response as the value
- no longer contains the logic for generating the `joinKeys`

`render` now:
- accepts a hash of query responses
- builds the `featureSets` and `joinKeys` arrays to pass to flatten by looping through `datasets` and merging in the query responses for `datasets` that don't have `data`

TODO:
- [x] `render()` should not set `this.data` I think we should add a step between `getData()` and `render()` to set the data
- [ ] add tests
- [ ] add an example that demonstrates this

Also, we should discuss:
- should we add another step between getData(0
- should we rename `getData()` to `query()`?
- what should `render()` return? 
- show should `show()` return?
