### PR TITLE
Chore/no transform

### DIFF
--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -85,44 +85,62 @@ export default class Chart {
     this._cedarSpecification = clone(spec)
   }
 
+  // TODO: rename to queryData() or query()?
   public getData() {
+    const names = []
     const requests = []
-    const joinKeys = []
-    const transformFunctions = []
+    const responseHash = {}
 
-    if (!!this.datasets && !!this.series) {
+    if (this.datasets) {
       this.datasets.forEach((dataset, i) => {
-        requests.push(getData(createFeatureServiceRequest(dataset)))
-        if (!dataset.merge) {
-          joinKeys.push(this.series[i].category.field)
+        // only query datasets that don't have inline data
+        if (!dataset.data) {
+          // TODO: make name required on datasets, or required if > 1 dataset?
+          names.push(dataset.name || `dataset${i}`)
+          requests.push(getData(createFeatureServiceRequest(dataset)))
         }
       })
-      //
-      // for (const series of this.series) {
-      //   joinKeys.push(series.category.field)
-      // }
     }
     return Promise.all(requests)
-      .then((responses) => {
-        return Promise.resolve({
-          responses,
-          joinKeys,
-          transformFunctions
-        })
-      }, (err) => {
-        return Promise.reject(err)
+    .then((responses) => {
+      responses.forEach((response, i) => {
+        responseHash[names[i]] = responses[i]
       })
+      return Promise.resolve(responseHash)
+    }, (err) => {
+      return Promise.reject(err)
+    })
   }
 
-  public render(result: any) {
-    this.data = flattenFeatures(result.responses, result.joinKeys, result.transformFunctions)
+  public render(datasetsData: {}) {
+    const featureSets = []
+    const joinKeys = []
+    // TODO: remove transformFucntions here and from flattenFeatures
+    const transformFunctions = []
+
+    // get array of featureSets from datasets data or datasetsData
+    this.datasets.forEach((dataset, i) => {
+      // TODO: make name required on datasets, or required if > 1 dataset?
+      const name = dataset.name || `dataset${i}`
+      // if dataset doesn't have inline data use data that was passed in
+      const featureSet = dataset.data || datasetsData[name]
+      if (featureSet) {
+        featureSets.push(featureSet)
+      }
+      // TODO: this is broken, there is not a 1:1 relationship between datasets/series
+      if (!dataset.merge) {
+        joinKeys.push(this.series[i].category.field)
+      }
+    })
+
+    this.data = flattenFeatures(featureSets, joinKeys, transformFunctions)
     cedarAmCharts(this._container, this.cedarSpecification, this.data)
   }
 
   public show() {
     return this.getData()
-      .then((response) => {
-        this.render(response)
-      })
+    .then((response) => {
+      this.render(response)
+    })
   }
 }

--- a/packages/cedar/src/flatten/flatten.ts
+++ b/packages/cedar/src/flatten/flatten.ts
@@ -1,59 +1,57 @@
-function _defaultTransformFunc(feature: any) {
-  return feature.attributes
-}
-
-export function getTransformFunc(transformFunc: any) {
-  return typeof transformFunc === 'function' ? transformFunc : _defaultTransformFunc
-}
-
-export function buildIndex(joinKeys: string[], featureSets: any[], transformFuncs: any[]) {
+export function buildIndex(joinKeys: string[], featureSets: any[]) {
   const index = {}
   featureSets.forEach((featureSet, i) => {
-    const transformFunc = getTransformFunc(transformFuncs[i])
-    featureSet.features.forEach((features, j) => {
-      const idx = features.attributes[joinKeys[i]]
-      if (index[idx] === undefined) {
-        index[idx] = []
+    featureSet.features.forEach((feature) => {
+      // the column that this dataset should be joined on
+      const joinKey = joinKeys[i]
+      const joinValue = feature.attributes[joinKeys[i]]
+      if (index[joinValue] === undefined) {
+        index[joinValue] = []
       }
-      index[idx].push(transformFunc(features))
+      index[joinValue].push(feature)
     })
   })
   return index
 }
 
-export function flattenFeatures(featureSets: any[], joinKeys: any[], transformFuncs: any[]) {
-  // TODO: Transform data
-  const features = []
+export function flattenFeatures(featureSets: any[], joinKeys: any[]) {
+  const rows = []
 
-  // If we aren't joining, but we are merging
+  // If we aren't joining, but we are appending
   if (joinKeys.length === 0) {
     featureSets.forEach((featureSet, i) => {
-      const transformFunc = getTransformFunc(transformFuncs[i])
-      featureSet.features.forEach((feature, j) => {
-        features.push(transformFunc(feature))
+      // const transformFunc = getTransformFunc(transformFuncs[i])
+      featureSet.features.forEach((feature) => {
+        rows.push(feature.attributes)
       })
     })
-    return features
+    return rows
   }
 
+  // TODO: if there's only 1 featureSet, do we need to build an index?
+  // couldn't we just return featureSet.features.map(feature => feature.attributes)
+
   // Otherwise join
-  const index = buildIndex(joinKeys, featureSets, transformFuncs)
+  // TODO: does joinKeys have to be 1:1 to featureSets? I think so
+  const index = buildIndex(joinKeys, featureSets)
   const key = joinKeys[0] // TODO: support different `category` keys
-  const keys = Object.keys(index)
-  keys.forEach((indKey, i) => {
-    const idxArr = index[indKey]
-    const feature = { categoryField: idxArr[0][key] }
-    idxArr.forEach((idx, k) => {
-      const attrKeys = Object.keys(idx)
-      attrKeys.forEach((ak, j) => {
-        const attr = `${ak}_${k}`
-        feature[attr] = idx[ak]
+  const uniqueValues = Object.keys(index)
+  uniqueValues.forEach((uniqueValue) => {
+    // all the features whose join field was equal to this value
+    const features = index[uniqueValue]
+    const row = { categoryField: features[0].attributes[key] }
+    features.forEach((feature, i) => {
+      const attributes = feature.attributes
+      Object.keys(attributes).forEach((attrKey) => {
+        // append the feature's index to the row's column name
+        const col = `${attrKey}_${i}`
+        row[col] = attributes[attrKey]
       })
     })
-    features.push(feature)
+    rows.push(row)
   })
 
-  return features
+  return rows
 }
 
 export default flattenFeatures

--- a/packages/cedar/test/flatten/flatten.spec.ts
+++ b/packages/cedar/test/flatten/flatten.spec.ts
@@ -4,45 +4,44 @@ import { buildIndex } from '../../src/flatten/flatten'
 import schoolResponse from '../data/schoolResponse'
 
 describe('Features should properly flatten', () => {
-  test('flattenFeatures properly flattens features when no joinKeys are present', () => {
+  test('flattenFeatures appends features when no joinKeys are present', () => {
     const data = {
       joinKeys: [],
-      featureSets: schoolResponse,
-      transformFuncs: []
+      featureSets: schoolResponse
     }
     const arr = [{Number_of_SUM: 13, Type: 'High School'}, {Number_of_SUM: 6, Type: 'Middle School'}, {Number_of_SUM: 1, Type: 'Elementary School'}, {Number_of_SUM: 1, Type: 'Elementary School'}, {Number_of_SUM: 8, Type: 'High School'}, {Number_of_SUM: 1, Type: 'Elementary School'}, {Number_of_SUM: 0, Type: 'Middle School'}]
 
-    expect(flatten(data.featureSets, data.joinKeys, data.transformFuncs)).toEqual(arr)
-    expect(true).toBe(true)
+    expect(flatten(data.featureSets, data.joinKeys)).toEqual(arr)
   })
 
   test('BuildIndex should properly build an index...', () => {
     const data = {
       joinKeys: ['Type', 'Type', 'Type'],
-      featureSets: schoolResponse,
-      transformFuncs: []
+      featureSets: schoolResponse
     }
     const result = {
-      'High School':
-         [ { Number_of_SUM: 13, Type: 'High School' },
-           { Number_of_SUM: 8, Type: 'High School' } ],
-      'Middle School':
-         [ { Number_of_SUM: 6, Type: 'Middle School' },
-           { Number_of_SUM: 0, Type: 'Middle School' } ],
-      'Elementary School':
-         [ { Number_of_SUM: 1, Type: 'Elementary School' },
-           { Number_of_SUM: 1, Type: 'Elementary School' },
-           { Number_of_SUM: 1, Type: 'Elementary School' } ]
-         }
+      'High School': [
+        { attributes: { Number_of_SUM: 13, Type: 'High School' } },
+        { attributes: { Number_of_SUM: 8, Type: 'High School' } }
+      ],
+      'Middle School': [
+        { attributes: { Number_of_SUM: 6, Type: 'Middle School' } },
+        { attributes: { Number_of_SUM: 0, Type: 'Middle School' } }
+      ],
+      'Elementary School': [
+        { attributes: { Number_of_SUM: 1, Type: 'Elementary School' } },
+        { attributes: { Number_of_SUM: 1, Type: 'Elementary School' } },
+        { attributes: { Number_of_SUM: 1, Type: 'Elementary School' } }
+      ]
+    }
 
-    expect(buildIndex(data.joinKeys, data.featureSets, [])).toEqual(result)
+    expect(buildIndex(data.joinKeys, data.featureSets)).toEqual(result)
   })
 
   test('flattenFeatures properly flattens when provided join keys', () => {
     const data = {
       joinKeys: ['Type', 'Type', 'Type'],
-      featureSets: schoolResponse,
-      transformFuncs: []
+      featureSets: schoolResponse
     }
 
     const result = [
@@ -71,6 +70,6 @@ describe('Features should properly flatten', () => {
       }
     ]
 
-    expect(flatten(data.featureSets, data.joinKeys, data.transformFuncs)).toEqual(result)
+    expect(flatten(data.featureSets, data.joinKeys)).toEqual(result)
   })
 })


### PR DESCRIPTION
Removes the notion of a dataset/feature level transform, b/c: it:
- wasn't actually implemented
- proabably wasn't the right implementation (an array of functions on the instance that had to be 1:1 w/ datasets)
- was making things harder to understand what was going on in flatten

Also removes `flattenFeatures()` in favor of explicit `join()` `append()` functions and renames the vars in that file so it is easier to read  and understand (i.e. doesn't look like it's been uglified)