### PR TITLE
fluent API, use append:true  add interfaces, and tests

### DIFF
--- a/explore/examples/bubble.json
+++ b/explore/examples/bubble.json
@@ -4,7 +4,7 @@
     {
       "url":"https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0",
       "query":{},
-      "merge": true
+      "append": true
     }
   ],
   "series": [

--- a/explore/examples/scatter.json
+++ b/explore/examples/scatter.json
@@ -2,7 +2,7 @@
   "type": "scatter",
   "datasets": [ {
     "url": "https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0",
-    "merge": true
+    "append": true
   }],
   "series": [
     {

--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -112,63 +112,71 @@ export default class Chart {
     }
   }
 
-  // TODO: replace w/ series(), see datasets()
-  public getSeries() {
-    return this._definition ? this._definition.series : undefined
-  }
-  public setSeries(series) {
-    if (this._definition) {
-      this._definition.series = series
-      return this
+  public series(newSeries: ISeries[]): Chart
+  public series(): ISeries[]
+  public series(newSeries?: any): any {
+    if (newSeries === undefined) {
+      return this._definition ? this._definition.series : undefined
     } else {
-      return this.definition({
-        series
-      })
+      if (this._definition) {
+        this._definition.series = newSeries
+        return this
+      } else {
+        return this.definition({
+          series: newSeries
+        })
+      }
     }
   }
 
-  // TODO: replace w/ type(), see datasets()
-  public getType() {
-    return this._definition ? this._definition.type : undefined
-  }
-  public setType(type) {
-    if (this._definition) {
-      this._definition.type = type
-      return this
+  public type(newType: string): Chart
+  public type(): string
+  public type(newType?: any): any {
+    if (newType === undefined) {
+      return this._definition ? this._definition.type : undefined
     } else {
-      return this.definition({
-        type
-      })
+      if (this._definition) {
+        this._definition.type = newType
+        return this
+      } else {
+        return this.definition({
+          type: newType
+        })
+      }
     }
   }
 
-  // TODO: replace w/ spefication(), see datasets()
-  public getSpecification() {
-    return this._definition ? this._definition.specification : undefined
-  }
-  public setSpecification(specification) {
-    if (this._definition) {
-      this._definition.specification = specification
-      return this
+  public specification(newSpecification: {}): Chart
+  public specification(): {}
+  public specification(newSpecification?: any): any {
+    if (newSpecification === undefined) {
+      return this._definition ? this._definition.specification : undefined
     } else {
-      return this.definition({
-        specification
-      })
+      if (this._definition) {
+        this._definition.specification = newSpecification
+        return this
+      } else {
+        return this.definition({
+          specification: newSpecification
+        })
+      }
     }
   }
 
-  // TODO: replace w/ overrides(), see datasets()
-  public getOverrides() {
-    return this._definition ? this._definition.overrides : undefined
-  }
-  public setOverrides(overrides) {
-    if (this._definition) {
-      this._definition.overrides = overrides
-      return this
+  public overrides(newOverrides: {}): Chart
+  public overrides(): {}
+  public overrides(newOverrides?: any): any {
+    if (newOverrides === undefined) {
+      return this._definition ? this._definition.overrides : undefined
     } else {
-      return this.definition({
-        overrides
-      })
+      if (this._definition) {
+        this._definition.overrides = newOverrides
+        return this
+      } else {
+        return this.definition({
+          overrides: newOverrides
+        })
+      }
     }
   }
 
@@ -208,7 +216,8 @@ export default class Chart {
   // update chart from inline data and query responses
   public updateData(datasetsData) {
     const datasets = this.datasets()
-    this._data = datasets ? getChartData(datasets, this.getSeries(), datasetsData) : []
+    const series = this.series()
+    this._data = datasets ? getChartData(datasets, series, datasetsData) : []
     return this
   }
 

--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -1,5 +1,6 @@
 import { cedarAmCharts, deepMerge } from '@esri/cedar-amcharts'
-import { flattenFeatures } from './flatten/flatten'
+// import { append, flatten, join } from './flatten/flatten'
+import flattenFeatures from './flatten/flatten'
 import { getData } from './query/query'
 import { createFeatureServiceRequest } from './query/url'
 
@@ -7,90 +8,176 @@ function clone(json) {
   return JSON.parse(JSON.stringify(json))
 }
 
-export default class Chart {
-  private _series: any[]
-  private _datasets: any[]
-  private _chartSpecification: any
-  private _cedarSpecification: any
-  private _data: any[]
-  private _overrides: any
-  private _container: string
+// TODO: move this to flatten, or?
+function getChartData(datasets: IDataset[], series: ISeries[], datasetsData?: {}) {
+  const featureSets = []
+  const joinKeys = []
+  // TODO: remove transformFucntions here and from flattenFeatures
+  const transformFunctions = []
 
-  constructor(container, options: any = {}) {
+  // get array of featureSets from datasets data or datasetsData
+  datasets.forEach((dataset, i) => {
+    // TODO: make name required on datasets, or required if > 1 dataset?
+    const name = dataset.name || `dataset${i}`
+    // if dataset doesn't have inline data use data that was passed in
+    const featureSet = dataset.data || datasetsData[name]
+    if (featureSet) {
+      featureSets.push(featureSet)
+    }
+    // TOOD: later support append, but for now, always do join
+    // assuming a 1:1 relationship between datasets and series
+    if (!dataset.append) {
+      joinKeys.push(series[i].category.field)
+    }
+  })
+
+  // flatten data from all datasets into a single table
+  // if there's only one dataset, just flatten the features
+  // if more than one, need to join or append the feature sets
+  // return (featureSets.length === 1) ? flatten(featureSets[0]) : (joinKeys.length > 0) ? join(featureSets, joinKeys) : append(featureSets)
+  return flattenFeatures(featureSets, joinKeys)
+}
+
+// TODO: where should these interfaces live?
+export interface IDataset {
+  name: string,
+  url?: string,
+  data?: any[],
+  query: {},
+  append?: boolean
+}
+
+export interface IField {
+  field: string,
+  label?: string
+}
+
+export interface ISeries {
+  source: string,
+  category?: IField,
+  value?: IField
+}
+
+export interface IDefinition {
+  datasets: IDataset[],
+  series: ISeries[],
+  type?: string
+  specification?: {}
+  overrides?: {}
+}
+
+export default class Chart {
+  private _container: string
+  private _definition: IDefinition
+  private _data: any[]
+
+  constructor(container, definition?) {
     if (!container) {
       throw new Error('A container is required')
     }
     this._container = container
 
-    // If there are datasets...
-    if (options.datasets) {
-      this.datasets = options.datasets
-    }
-    // If there are series...
-    if (options.series) {
-      this.series = options.series
-    }
-
-    if (options) {
-      this.cedarSpecification = options
+    if (definition) {
+      // set the definition
+      this.setDefinition(clone(definition))
     }
   }
 
   // Setters and getters
-
-  // Datasets
-  public get datasets(): any[] {
-    return this._datasets
+  public getDefinition() {
+    return this._definition
   }
-  public set datasets(val: any[]) {
-    // TODO: type any[] can't be a function, why is this code checking for that
-    if (typeof val !== 'function' && (val instanceof Array)) {
-      this._datasets = clone(val)
+  public setDefinition(definition) {
+    this._definition = definition
+    return this
+  }
+
+  public getDatasets() {
+    return this._definition ? this._definition.datasets : undefined
+  }
+  public setDatasets(datasets) {
+    if (this._definition) {
+      this._definition.datasets = datasets
+      return this
+    } else {
+      return this.setDefinition({
+        datasets
+      })
     }
   }
 
-  // Series
-  public get series(): any[] {
-    return this._series
+  public getSeries() {
+    return this._definition ? this._definition.series : undefined
   }
-  public set series(val: any[]) {
-    // TODO: type any[] can't be a function, why is this code checking for that
-    if (typeof val !== 'function' && (val instanceof Array)) {
-      this._series = deepMerge([], val)
+  public setSeries(series) {
+    if (this._definition) {
+      this._definition.series = series
+      return this
+    } else {
+      return this.setDefinition({
+        series
+      })
     }
   }
 
-  // Data
-  public get data(): any[] {
+  public getType() {
+    return this._definition ? this._definition.type : undefined
+  }
+  public setType(type) {
+    if (this._definition) {
+      this._definition.type = type
+      return this
+    } else {
+      return this.setDefinition({
+        type
+      })
+    }
+  }
+
+  public getSpecification() {
+    return this._definition ? this._definition.specification : undefined
+  }
+  public setSpecification(specification) {
+    if (this._definition) {
+      this._definition.specification = specification
+      return this
+    } else {
+      return this.setDefinition({
+        specification
+      })
+    }
+  }
+
+  public getOverrides() {
+    return this._definition ? this._definition.overrides : undefined
+  }
+  public setOverrides(overrides) {
+    if (this._definition) {
+      this._definition.overrides = overrides
+      return this
+    } else {
+      return this.setDefinition({
+        overrides
+      })
+    }
+  }
+
+  // chart data
+  public getData() {
     return this._data
   }
 
-  // Chart Specification
-  public get chartSpecification(): any {
-    return this._chartSpecification
-  }
-  public set chartSpecification(chartSpec: any) {
-    this._chartSpecification = clone(chartSpec)
-  }
-
-  // Cedar Spec
-  public get cedarSpecification(): any {
-    return this._cedarSpecification
-  }
-  public set cedarSpecification(spec: any) {
-    // NOTE: we can only use clone here if spec is JSON
-    this._cedarSpecification = clone(spec)
-  }
-
+  // query non-inline datasets
   public queryData() {
     const names = []
     const requests = []
     const responseHash = {}
+    const datasets = this.getDatasets()
 
-    if (this.datasets) {
-      this.datasets.forEach((dataset, i) => {
+    if (datasets) {
+      datasets.forEach((dataset, i) => {
         // only query datasets that don't have inline data
-        if (!dataset.data) {
+        if (dataset.url) {
           // TODO: make name required on datasets, or required if > 1 dataset?
           names.push(dataset.name || `dataset${i}`)
           requests.push(getData(createFeatureServiceRequest(dataset)))
@@ -108,36 +195,21 @@ export default class Chart {
     })
   }
 
-  public updateData(datasetsData: {}) {
-    const featureSets = []
-    const joinKeys = []
-    // TODO: remove transformFucntions here and from flattenFeatures
-    const transformFunctions = []
-
-    // get array of featureSets from datasets data or datasetsData
-    this.datasets.forEach((dataset, i) => {
-      // TODO: make name required on datasets, or required if > 1 dataset?
-      const name = dataset.name || `dataset${i}`
-      // if dataset doesn't have inline data use data that was passed in
-      const featureSet = dataset.data || datasetsData[name]
-      if (featureSet) {
-        featureSets.push(featureSet)
-      }
-      // TODO: this is broken, there is not a 1:1 relationship between datasets/series
-      if (!dataset.merge) {
-        joinKeys.push(this.series[i].category.field)
-      }
-    })
-
-    this._data = flattenFeatures(featureSets, joinKeys)
+  // update chart from inline data and query responses
+  public updateData(datasetsData) {
+    const datasets = this.getDatasets()
+    this._data = datasets ? getChartData(datasets, this.getSeries(), datasetsData) : []
     return this
   }
 
+  // re-draw the chart based on the current state
   public render() {
-    cedarAmCharts(this._container, this.cedarSpecification, this.data)
+    cedarAmCharts(this._container, this.getDefinition(), this.getData())
     return this
   }
 
+  // rollup the query, update, and render functions
+  // useful for showing the chart for the first time
   public show() {
     return this.queryData()
     .then((response) => {

--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -1,7 +1,7 @@
 import { cedarAmCharts, deepMerge } from '@esri/cedar-amcharts'
 // import { append, flatten, join } from './flatten/flatten'
 import flattenFeatures from './flatten/flatten'
-import { data } from './query/query'
+import { getData } from './query/query'
 import { createFeatureServiceRequest } from './query/url'
 
 function clone(json) {
@@ -190,7 +190,7 @@ export default class Chart {
         if (dataset.url) {
           // TODO: make name required on datasets, or required if > 1 dataset?
           names.push(dataset.name || `dataset${i}`)
-          requests.push(data(createFeatureServiceRequest(dataset)))
+          requests.push(getData(createFeatureServiceRequest(dataset)))
         }
       })
     }

--- a/packages/cedar/test/Chart.spec.ts
+++ b/packages/cedar/test/Chart.spec.ts
@@ -42,20 +42,20 @@ describe('new Chart w/o definition', () => {
   beforeEach(() => {
     chart = new Chart('chart')
   })
-  test('getDefinition should return undefined', () => {
-    expect(chart.getDefinition()).toBeUndefined()
+  test('definition should return undefined', () => {
+    expect(chart.definition()).toBeUndefined()
   })
-  test('getData should return undefined', () => {
-    expect(chart.getData()).toBeUndefined()
+  test('data should return undefined', () => {
+    expect(chart.data()).toBeUndefined()
   })
-  test('getData should return undefined', () => {
-    expect(chart.getData()).toBeUndefined()
+  test('data should return undefined', () => {
+    expect(chart.data()).toBeUndefined()
   })
-  test('setDefinition should set the definition', () => {
-    expect(chart.setDefinition(barDefinition).getDefinition()).toEqual(barDefinition)
+  test('definition should set the definition', () => {
+    expect(chart.definition(barDefinition).definition()).toEqual(barDefinition)
   })
-  test('setDatasets should set the definition.dataset', () => {
-    expect(chart.setDatasets(barDefinition.datasets).getDatasets()).toEqual(barDefinition.datasets)
+  test('datasets should set the definition.dataset', () => {
+    expect(chart.datasets(barDefinition.datasets).datasets()).toEqual(barDefinition.datasets)
   })
   test('setSeries should set the definition.series', () => {
     expect(chart.setSeries(barDefinition.series).getSeries()).toEqual(barDefinition.series)
@@ -77,7 +77,7 @@ describe('when updating data', () => {
     const queryDataResponse = {
       Number_of_SUM: featureServiceResponse
     }
-    expect(chart.updateData(queryDataResponse).getData()).toEqual(expectedChartData.barSingleDataset)
+    expect(chart.updateData(queryDataResponse).data()).toEqual(expectedChartData.barSingleDataset)
   })
 })
 
@@ -156,11 +156,11 @@ describe('new Chart w/ definition', () => {
     /* tslint:enable */
     chart = new Chart('chart', definition)
   })
-  test('getDefinition should return definition', () => {
-    expect(chart.getDefinition()).toEqual(definition)
+  test('definition should return definition', () => {
+    expect(chart.definition()).toEqual(definition)
   })
-  test('getDatasets should equal definition.datasets', () => {
-    expect(chart.getDatasets()).toEqual(definition.datasets)
+  test('datasets should equal definition.datasets', () => {
+    expect(chart.datasets()).toEqual(definition.datasets)
   })
   test('getSeries should equal definition.series', () => {
     expect(chart.getSeries()).toEqual(definition.series)

--- a/packages/cedar/test/Chart.spec.ts
+++ b/packages/cedar/test/Chart.spec.ts
@@ -57,14 +57,14 @@ describe('new Chart w/o definition', () => {
   test('datasets should set the definition.dataset', () => {
     expect(chart.datasets(barDefinition.datasets).datasets()).toEqual(barDefinition.datasets)
   })
-  test('setSeries should set the definition.series', () => {
-    expect(chart.setSeries(barDefinition.series).getSeries()).toEqual(barDefinition.series)
+  test('series should set the definition.series', () => {
+    expect(chart.series(barDefinition.series).series()).toEqual(barDefinition.series)
   })
-  test('setType should set the definition.type', () => {
-    expect(chart.setType(barDefinition.type).getType()).toEqual(barDefinition.type)
+  test('type should set the definition.type', () => {
+    expect(chart.type(barDefinition.type).type()).toEqual(barDefinition.type)
   })
-  test('setOverrides should set the definition.overrides', () => {
-    expect(chart.setOverrides(barDefinition.overrides).getOverrides()).toEqual(barDefinition.overrides)
+  test('overrides should set the definition.overrides', () => {
+    expect(chart.overrides(barDefinition.overrides).overrides()).toEqual(barDefinition.overrides)
   })
 })
 
@@ -162,13 +162,13 @@ describe('new Chart w/ definition', () => {
   test('datasets should equal definition.datasets', () => {
     expect(chart.datasets()).toEqual(definition.datasets)
   })
-  test('getSeries should equal definition.series', () => {
-    expect(chart.getSeries()).toEqual(definition.series)
+  test('series should equal definition.series', () => {
+    expect(chart.series()).toEqual(definition.series)
   })
-  test('getType should equal definition.type', () => {
-    expect(chart.getType()).toEqual(definition.type)
+  test('type should equal definition.type', () => {
+    expect(chart.type()).toEqual(definition.type)
   })
-  test('getSpecification should equal definition.specification', () => {
-    expect(chart.getSpecification()).toEqual(definition.specification)
+  test('specification should equal definition.specification', () => {
+    expect(chart.specification()).toEqual(definition.specification)
   })
 })

--- a/packages/cedar/test/Chart.spec.ts
+++ b/packages/cedar/test/Chart.spec.ts
@@ -1,0 +1,174 @@
+import {} from 'jest'
+import Chart from '../src/Chart'
+import expectedChartData from './data/chartData'
+import featureServiceResponse from './data/featureServiceResponse'
+/* tslint:disable */
+const barDefinition = {
+  "type": "bar",
+  "datasets": [
+    {
+      "url": "https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0",
+      "name": "Number_of_SUM",
+      "query": {
+        "orderByFields": "Number_of_SUM DESC",
+        "groupByFieldsForStatistics": "Type",
+        "outStatistics": [
+          {
+            "statisticType": "sum",
+            "onStatisticField": "Number_of",
+            "outStatisticFieldName": "Number_of_SUM"
+          }
+        ]
+      }
+    }
+  ],
+  "series": [
+    {
+      "category": {"field": "Type", "label": "Type"},
+      "value": {"field": "Number_of_SUM", "label": "Number of Students"},
+      "source": "Number_of_SUM"
+    }
+  ],
+  "overrides": {
+    "categoryAxis": {
+      "labelRotation": -45
+    }
+  }
+}
+/* tslint:enable */
+
+describe('new Chart w/o definition', () => {
+  let chart
+  beforeEach(() => {
+    chart = new Chart('chart')
+  })
+  test('getDefinition should return undefined', () => {
+    expect(chart.getDefinition()).toBeUndefined()
+  })
+  test('getData should return undefined', () => {
+    expect(chart.getData()).toBeUndefined()
+  })
+  test('getData should return undefined', () => {
+    expect(chart.getData()).toBeUndefined()
+  })
+  test('setDefinition should set the definition', () => {
+    expect(chart.setDefinition(barDefinition).getDefinition()).toEqual(barDefinition)
+  })
+  test('setDatasets should set the definition.dataset', () => {
+    expect(chart.setDatasets(barDefinition.datasets).getDatasets()).toEqual(barDefinition.datasets)
+  })
+  test('setSeries should set the definition.series', () => {
+    expect(chart.setSeries(barDefinition.series).getSeries()).toEqual(barDefinition.series)
+  })
+  test('setType should set the definition.type', () => {
+    expect(chart.setType(barDefinition.type).getType()).toEqual(barDefinition.type)
+  })
+  test('setOverrides should set the definition.overrides', () => {
+    expect(chart.setOverrides(barDefinition.overrides).getOverrides()).toEqual(barDefinition.overrides)
+  })
+})
+
+describe('when updating data', () => {
+  let chart
+  beforeEach(() => {
+    chart = new Chart('chart', barDefinition)
+  })
+  test('it should update _data', () => {
+    const queryDataResponse = {
+      Number_of_SUM: featureServiceResponse
+    }
+    expect(chart.updateData(queryDataResponse).getData()).toEqual(expectedChartData.barSingleDataset)
+  })
+})
+
+describe('new Chart w/ definition', () => {
+  let chart
+  let definition
+  beforeAll(() => {
+    /* tslint:disable */
+    definition = {
+      "type": "bar",
+      "datasets": [
+        {
+          "url": "https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0",
+          "name": "Jordan",
+          "query": {
+            "where": "City='Jordan'",
+            "orderByFields": "Number_of_SUM DESC",
+            "groupByFieldsForStatistics": "Type",
+            "outStatistics": [{
+              "statisticType": "sum",
+              "onStatisticField": "Number_of",
+              "outStatisticFieldName": "Number_of_SUM"
+            }]
+          }
+        },
+        {
+          "url": "https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0",
+          "name": "Dewitt",
+          "query": {
+            "where": "City='Dewitt'",
+            "orderByFields": "Number_of_SUM DESC",
+            "groupByFieldsForStatistics": "Type",
+            "outStatistics": [{
+              "statisticType": "sum",
+              "onStatisticField": "Number_of",
+              "outStatisticFieldName": "Number_of_SUM"
+            }]
+          }
+        },
+        {
+          "url": "https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0",
+          "name": "Fayetteville",
+          "query": {
+            "where": "City='Fayetteville'",
+            "orderByFields": "Number_of_SUM DESC",
+            "groupByFieldsForStatistics": "Type",
+            "outStatistics": [{
+              "statisticType": "sum",
+              "onStatisticField": "Number_of",
+              "outStatisticFieldName": "Number_of_SUM"
+            }]
+          }
+        }
+      ],
+      "series": [
+        {
+          "category": {"field": "Type", "label": "Type"},
+          "group": true,
+          "value": { "field": "Number_of_SUM", "label": "Jordan Students"},
+          "source": "Jordan"
+        },
+        {
+          "category": {"field": "Type", "label": "Type"},
+          "group": true,
+          "value": { "field": "Number_of_SUM", "label": "Dewitt Students"},
+          "source": "Dewitt"
+        },
+        {
+          "category": {"field": "Type", "label": "Type"},
+          "group": true,
+          "value": { "field": "Number_of_SUM", "label": "Fayetteville Students"},
+          "source": "Fayetteville"
+        }
+      ]
+    }
+    /* tslint:enable */
+    chart = new Chart('chart', definition)
+  })
+  test('getDefinition should return definition', () => {
+    expect(chart.getDefinition()).toEqual(definition)
+  })
+  test('getDatasets should equal definition.datasets', () => {
+    expect(chart.getDatasets()).toEqual(definition.datasets)
+  })
+  test('getSeries should equal definition.series', () => {
+    expect(chart.getSeries()).toEqual(definition.series)
+  })
+  test('getType should equal definition.type', () => {
+    expect(chart.getType()).toEqual(definition.type)
+  })
+  test('getSpecification should equal definition.specification', () => {
+    expect(chart.getSpecification()).toEqual(definition.specification)
+  })
+})

--- a/packages/cedar/test/data/chartData.ts
+++ b/packages/cedar/test/data/chartData.ts
@@ -1,0 +1,6 @@
+/* tslint:disable */
+const barSingleDataset = [{ "Number_of_SUM_0": 261, "Type_0": "Middle School", "categoryField": "Middle School" }, { "Number_of_SUM_0": 252, "Type_0": "Elementary School", "categoryField": "Elementary School" }, { "Number_of_SUM_0": 184, "Type_0": "High School", "categoryField": "High School" }, { "Number_of_SUM_0": 159, "Type_0": "Middle School (7&8)", "categoryField": "Middle School (7&8)" }, { "Number_of_SUM_0": 98, "Type_0": "K-8", "categoryField": "K-8" }, { "Number_of_SUM_0": 31, "Type_0": "Junior/Senior High School", "categoryField": "Junior/Senior High School" }, { "Number_of_SUM_0": 22, "Type_0": "Junior High School", "categoryField": "Junior High School" }, { "Number_of_SUM_0": 3, "Type_0": "K-12", "categoryField": "K-12" }, { "Number_of_SUM_0": 1, "Type_0": "Intermediate School", "categoryField": "Intermediate School" }, { "Number_of_SUM_0": 0, "Type_0": "Alternative School", "categoryField": "Alternative School" }, { "Number_of_SUM_0": 0, "Type_0": "High School Annex", "categoryField": "High School Annex" }, { "Number_of_SUM_0": 0, "Type_0": "Middle School High School", "categoryField": "Middle School High School" }, { "Number_of_SUM_0": 0, "Type_0": "Pre-K", "categoryField": "Pre-K" }]
+
+export default {
+  barSingleDataset
+}

--- a/packages/cedar/test/index.spec.ts
+++ b/packages/cedar/test/index.spec.ts
@@ -1,38 +1,8 @@
 import {} from 'jest'
 import cedar from '../src/index'
 
-describe('Cedar initial test', () => {
-  test('Cedar is present', () => {
-    const opts = {
-      type: 'bar',
-      datasets: [
-        {
-          url: 'https://services.arcgis.com/uDTUpUPbk8X8mXwl/arcgis/rest/services/Public_Schools_in_Onondaga_County/FeatureServer/0',
-          query: {
-            orderByFields: 'Number_of_SUM DESC',
-            groupByFieldsForStatistics: 'Type',
-            outStatistics: [
-              {
-                statisticType: 'sum',
-                onStatisticField: 'Number_of',
-                outStatisticFieldName: 'Number_of_SUM'
-              }
-            ]
-          }
-        }
-      ],
-      series: [
-        {
-          category: {field: 'Type', label: 'Type'},
-          value: {field: 'Number_of_SUM', label: 'Number of Students'}
-        }
-      ],
-      overrides: {
-        categoryAxis: {
-          labelRotation: -45
-        }
-      }
-    }
-    const chart = new cedar.Chart('chart', opts)
+describe('cedar namespace', () => {
+  test('Chart is present', () => {
+    expect(cedar.Chart).not.toBeUndefined()
   })
 })


### PR DESCRIPTION
resolves #315 

Went w/ "Leaflet style" b/c TS was giving me errors when I tried to use the return values that could return more than one type (i.e. some value when used as a getter or `this` when used as a setter). I'm guessing there's some way to cast values as one of the possible return types, but I didn't want to spend too much time figuring that out. We can spend some more time on that if needed. Includes tests for new setters/getters.

Also:
- adds a test for `updateData` since I refactored that code a bit and wanted to have a sanity check that I didn't break it
- addresses #307 by at least renaming `dataset.merge` to `dataset.append`.
