### PR TITLE
don't show labels by default on series

### DIFF
--- a/packages/cedar-amcharts/src/render/render.ts
+++ b/packages/cedar-amcharts/src/render/render.ts
@@ -60,7 +60,6 @@ export function fillInSpec(spec: any, definition: any) {
         // TODO: map other fields besides value like color, size, etc
 
         graph.balloonText = `${graph.title} [[${spec.categoryField}]]: <b>[[${graph.valueField}]]</b>`
-        graph.labelText = `[[${series.value.field}]]`
 
         spec.titleField = 'categoryField'
         spec.valueField = graph.valueField
@@ -78,8 +77,6 @@ export function fillInSpec(spec: any, definition: any) {
           graph.balloonText = `${series.name} [[${series.label}]] <br/>
           ${series.category.label}: [[${series.category.field}]],
           ${series.value.label}: [[${series.value.field}]]`
-
-          graph.labelText = ''
 
           // bubble
           if (spec.type === 'xy' && series.size) {

--- a/packages/cedar-amcharts/test/data/builtBarSpec.ts
+++ b/packages/cedar-amcharts/test/data/builtBarSpec.ts
@@ -13,8 +13,7 @@ const builtBarSpec = {
       "type": "column",
       "title": "Number of Students",
       "valueField": "Number_of_SUM",
-      "balloonText": "Number of Students [[categoryField]]: <b>[[Number_of_SUM]]</b>",
-      "labelText": "[[Number_of_SUM]]"
+      "balloonText": "Number of Students [[categoryField]]: <b>[[Number_of_SUM]]</b>"
     }
   ],
   "legend": {},


### PR DESCRIPTION
Cedar v0 didn't do this, so is there a reason that are we defaulting to showing labels on each series now?

Due to #344 this is impossible to override, so at least for now I think we ought to align w/ the previous defaults and what is needed by Hub.

After merging, charts will look like:

![image](https://user-images.githubusercontent.com/662944/33147447-a10dd8e8-cf7c-11e7-8021-f6ab2ab815ed.png)

