### PR TITLE
text, background, and chart colors wired in

### DIFF
--- a/packages/cedar-amcharts/src/render/render.ts
+++ b/packages/cedar-amcharts/src/render/render.ts
@@ -78,6 +78,17 @@ export function fillInSpec(spec: any, definition: any) {
   if (definition.legend) {
     spec.legend.enabled = definition.legend.enable
   }
+  // If we have styles....
+  if (definition.styles) {
+    // Snag out styles for brevities sake
+    const styles = definition.styles
+    // If a backgroundColor..
+    if (styles.backgroundColor) { spec.backgroundColor = styles.backgroundColor }
+    // If a backgroundAlpha..
+    if (styles.backgroundAlpha) { spec.backgroundAlpha = styles.backgroundAlpha }
+    // If a textColor
+    if (styles.textColor) { spec.color = styles.textColor }
+  }
 
   // Iterate over datasets
   definition.datasets.forEach((dataset, d) => {
@@ -101,6 +112,11 @@ export function fillInSpec(spec: any, definition: any) {
         }
         /* tslint:enable */
         // TODO: map other fields besides value like color, size, etc
+
+        // handle le color
+        if (definition.styles && definition.styles.colors) {
+          graph.lineColor = definition.styles.colors[s]
+        }
 
         graph.balloonText = `${graph.title} [[${spec.categoryField}]]: <b>[[${graph.valueField}]]</b>`
 

--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -58,7 +58,14 @@ export interface ISeries {
 }
 
 export interface ILegend {
-  enable: boolean
+  enable?: boolean
+}
+
+export interface IStyles {
+  backgroundColor?: string,
+  backgroundAlpha?: number,
+  colors?: string[],
+  textColor?: string
 }
 
 export interface IDefinition {
@@ -67,7 +74,8 @@ export interface IDefinition {
   type?: string
   specification?: {}
   overrides?: {},
-  legend?: ILegend
+  legend?: ILegend,
+  styles?: IStyles
 }
 
 export default class Chart {
@@ -133,6 +141,12 @@ export default class Chart {
   public legend(): ILegend
   public legend(newLegend?: any): any {
     return this._definitionAccessor('legend', newLegend)
+  }
+
+  public styles(newStyles: IStyles): Chart
+  public styles(): IStyles
+  public styles(newStyles?: any): any {
+    return this._definitionAccessor('styles', newStyles)
   }
 
   // data is read only


### PR DESCRIPTION
Closes #375 

@tomwayson Background color and background alpha go hand in hand. Alpha defaults to 0, meaning that if you don't set it you don't have the background color show up. I'd like to do something like: `styles: { background: { color: '#xyz', alpha: 0.3 } }`

Does that seem reasonable to you?