### PR TITLE
fix fatal errors in IE11 #386

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -88,82 +88,112 @@
   <!-- example code for this page -->
   <script src="https://ajaxorg.github.io/ace-builds/src/ace.js" type="text/javascript" charset="utf-8"></script>
   <script>
-  // set up editor
-  var editor = ace.edit("editor");
+    function browserSupportsAllFeatures() {
+      return window.fetch;
+    }
+
+    function loadScript(src, done) {
+      var js = document.createElement('script');
+      js.src = src;
+      js.onload = function() {
+        done();
+      };
+      js.onerror = function() {
+        done(new Error('Failed to load script ' + src));
+      };
+      document.head.appendChild(js);
+    }
+    
+    function main(err) {
+      // Initiate all other code paths.
+      // If there's an error loading the polyfills, handle that
+      // case gracefully and track that the error occurred.
+      // set up editor
+      editor = ace.edit("editor");
       editor.setTheme("ace/theme/xcode");
       editor.getSession().setMode("ace/mode/json");
 
-  // build list off styles
-  var styles = ["bar", "bar-grouped", "bar-stacked", "bar-horizontal", "radar", "bubble", "area", "line", "pie", "scatter"];
-  buildMenu(styles);
+      // build list off styles
+      var styles = ["bar", "bar-grouped", "bar-stacked", "bar-horizontal", "radar", "bubble", "area", "line", "pie", "scatter"];
+      buildMenu(styles);
 
-  // initialize editor to default style
-  var initialStyle = parseStyleFromUrl() || styles[0];
-  loadExample(initialStyle);
-
-  function buildMenu(styles) {
-    var ul = document.createElement('ul');
-    document.getElementById('styleList').appendChild(ul);
-
-    function buildOption(filename) {
-      var li = document.createElement('li');
-      li.setAttribute('class','style');
-      li.setAttribute('onclick','loadExample("' + filename + '")');
-      ul.appendChild(li);
-      t = document.createTextNode(filename);
-      li.innerHTML=li.innerHTML + filename;
+      // initialize editor to default style
+      var initialStyle = parseStyleFromUrl() || styles[0];
+      loadExample(initialStyle);
     }
 
-    styles.forEach(function(style, index, arr) {
-      buildOption(style);
-    });
+    function buildMenu(styles) {
+      var ul = document.createElement('ul');
+      document.getElementById('styleList').appendChild(ul);
 
-    // Custom option
-    buildOption("Custom")
+      function buildOption(filename) {
+        var li = document.createElement('li');
+        li.setAttribute('class','style');
+        li.setAttribute('onclick','loadExample("' + filename + '")');
+        ul.appendChild(li);
+        t = document.createTextNode(filename);
+        li.innerHTML=li.innerHTML + filename;
+      }
 
-    return ul;
-  }
+      styles.forEach(function(style, index, arr) {
+        buildOption(style);
+      });
 
-  function parseStyleFromUrl () {
-    // Ex: ?type=bar
-    // for now return the first query string param (if any)
-    return location.search && location.search.split('=')[1];
-  }
+      // Custom option
+      buildOption("Custom")
 
-  function loadExample(style) {
-    if(style.length == 0 || style == "Custom") {
-      editor.setValue('');
-      return;
+      return ul;
     }
-    loadFile(style, function(configJson) {
-      editor.setValue(configJson); // document.getElementById("editor").value;
+
+    function parseStyleFromUrl () {
+      // Ex: ?type=bar
+      // for now return the first query string param (if any)
+      return location.search && location.search.split('=')[1];
+    }
+
+    function loadExample(style) {
+      if(style.length == 0 || style == "Custom") {
+        editor.setValue('');
+        return;
+      }
+      loadFile(style, function(configJson) {
+        editor.setValue(configJson); // document.getElementById("editor").value;
+        var config = JSON.parse(configJson);
+        displayChart(config);
+      });
+    }
+
+    function loadEditor() {
+      var configJson = editor.getValue(); // document.getElementById("editor").value;
       var config = JSON.parse(configJson);
       displayChart(config);
-    });
-  }
-  function loadEditor() {
-    var configJson = editor.getValue(); // document.getElementById("editor").value;
-    var config = JSON.parse(configJson);
-    displayChart(config);
-  }
+    }
 
-  let chart;
-  function displayChart(config) {
+    function displayChart(config) {
       chart = new cedar.Chart("chart", config);
       chart.show()
-  }
+    }
 
-  function loadFile(style, cb) {
-    var xhttp = new XMLHttpRequest();
-    xhttp.onreadystatechange = function() {
-        if (this.readyState == 4 && this.status == 200) {
-          // Typical action to be performed when the document is ready:
-          cb(xhttp.responseText)
-        }
-    };
-    xhttp.open("GET", "./examples/" + style + ".json", true);
-    xhttp.send();
-  }
+    function loadFile(style, cb) {
+      var xhttp = new XMLHttpRequest();
+      xhttp.onreadystatechange = function() {
+          if (this.readyState == 4 && this.status == 200) {
+            // Typical action to be performed when the document is ready:
+            cb(xhttp.responseText)
+          }
+      };
+      xhttp.open("GET", "./examples/" + style + ".json", true);
+      xhttp.send();
+    }
+
+    let editor, chart;
+    if (browserSupportsAllFeatures()) {
+      // Browsers that support all features run `main()` immediately.
+      main();
+    } else {
+      // All other browsers loads polyfills and then run `main()`.
+      loadScript('https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch', main);
+    }
   </script>
 </body>
 </html>

--- a/packages/cedar/CHANGELOG.md
+++ b/packages/cedar/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- fix fatal errors in IE11 [#386](https://github.com/Esri/cedar/issues/386)
+### Changed
+- add fetch polyfill to docs site if accessed by IE11
+
 ## [1.0.0-beta.1]
 ### Changed
 - release script copies root README to packages/cedar before publishi

--- a/packages/cedar/src/query/url.ts
+++ b/packages/cedar/src/query/url.ts
@@ -12,30 +12,38 @@ export function defaultQuery() {
 }
 
 export function createQueryParams(query: any = {}): any {
-  // merge in default query params
-  const queryParams = Object.assign(defaultQuery(), query)
+  // start w/ default query params
+  const queryParams = defaultQuery()
 
   // Handle bbox
-  if (queryParams.bbox) {
+  if (query.bbox) {
     // make sure a geometry was not also passed in
-    if (queryParams.geometry) {
+    if (query.geometry) {
       throw new Error('Dataset.query can not have both a geometry and a bbox specified')
     }
     // Get the bbox (w,s,e,n)
-    const bboxArr = queryParams.bbox.split(',')
+    const bboxArr = query.bbox.split(',')
 
     // Remove it so it's not serialized as-is
-    delete queryParams.bbox
+    delete query.bbox
 
     // cook it into a json string
-    queryParams.geometry = {
+    query.geometry = JSON.stringify({
       xmin: Number(bboxArr[0]),
       ymin: Number(bboxArr[1]),
       xmax: Number(bboxArr[2]),
       ymax: Number(bboxArr[3])
-    }
+    })
     // set spatial ref as geographic
-    queryParams.inSR = '4326'
+    query.inSR = '4326'
+  }
+
+  // override w/ params that were passed in
+  for (const key in query) {
+    if (query.hasOwnProperty(key)) {
+      const param = query[key]
+      queryParams[key] = typeof param === 'object' ? JSON.stringify(param) : param
+    }
   }
 
   return queryParams

--- a/packages/cedar/test/query/url.spec.ts
+++ b/packages/cedar/test/query/url.spec.ts
@@ -59,17 +59,17 @@ describe('createQueryParams', () => {
       f:  'json',
       groupByFieldsForStatistics: 'Type',
       orderByFields: 'Number_of_SUM DESC',
-      outStatistics: [{
+      outStatistics: JSON.stringify([{
         statisticType: 'sum',
         onStatisticField: 'Number_of',
         outStatisticFieldName: 'Number_of_SUM'
-      }],
-      geometry: {
+      }]),
+      geometry: JSON.stringify({
         xmin: -104,
         ymin: 35.6,
         xmax: -94.32,
         ymax: 41
-      },
+      }),
       inSR: '4326'
   }
     expect(createQueryParams(dataset.query)).toEqual(result)


### PR DESCRIPTION
- remove use of Object.assign
- stringify objects before serializing into query string for IE11
- add polyfills to docs site if accessed by IE11