### PR TITLE
inlined spec now hooked up properly

### DIFF
--- a/packages/cedar-amcharts/CHANGELOG.md
+++ b/packages/cedar-amcharts/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - legend.enable is now legend.visible
 - Text colors have been changed to pass color contrast ratio on white backgrounds
+### Fixed
+- Specifications that are passed in are actually supported
 
 ## 1.0.0-beta.1
 ### Added

--- a/packages/cedar-amcharts/src/index.ts
+++ b/packages/cedar-amcharts/src/index.ts
@@ -2,7 +2,7 @@ import render from './render/render'
 
 export function cedarAmCharts(elementId: string, definition: any, data?: any[]) {
   if ((!elementId || !definition || !data) && (definition.type && definition.type !== 'custom')) {
-    const err = new Error('Element Id, definitionification, and data are all required.')
+    const err = new Error('Element Id, definition, and data are all required.')
     throw err
   }
 

--- a/packages/cedar-amcharts/src/index.ts
+++ b/packages/cedar-amcharts/src/index.ts
@@ -1,15 +1,15 @@
 import render from './render/render'
 
-export function cedarAmCharts(elementId: string, spec: any, data?: any[]) {
-  if ((!elementId || !spec || !data) && (spec.type && spec.type !== 'custom')) {
-    const err = new Error('Element Id, specification, and data are all required.')
+export function cedarAmCharts(elementId: string, definition: any, data?: any[]) {
+  if ((!elementId || !definition || !data) && (definition.type && definition.type !== 'custom')) {
+    const err = new Error('Element Id, definitionification, and data are all required.')
     throw err
   }
 
-  if (spec.type && spec.type === 'custom') {
-    return render.renderChart(elementId, spec)
+  if (definition.type && definition.type === 'custom') {
+    return render.renderChart(elementId, definition)
   }
-  return render.renderChart(elementId, spec, data)
+  return render.renderChart(elementId, definition, data)
 }
 
 export default cedarAmCharts

--- a/packages/cedar-amcharts/src/render/render.ts
+++ b/packages/cedar-amcharts/src/render/render.ts
@@ -11,7 +11,11 @@ export function renderChart(elementId: string, definition: any, data?: any) {
   }
 
   // Clone/copy spec and data
-  let spec = fetchSpec(definition.type)
+  // Longer than normal conditional so setting as its own const
+  const hasSpecAndIsntString = definition.specification && typeof definition.specification !== 'string'
+  // ternary checking to see if there is a def.spec and that it is NOT a string (url)
+  // if true than return def.spec. If not true than fetch a premade spec
+  let spec = hasSpecAndIsntString ? clone(definition.specification) : fetchSpec(definition.type)
   const copyData = clone(data)
 
   // Set the spec's data

--- a/packages/cedar/CHANGELOG.md
+++ b/packages/cedar/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - remove extraneous dependency on amcharts in @esri/cedar
+- Specifications that are passed in are actually supported
 
 ## [1.0.0-beta.2]
 ### Fixed


### PR DESCRIPTION
@tomwayson There are some things to do....

- [ ] what do we want to do about `type: custom`.
- [ ] If a url is passed in/fetching the spec.
- [x] cleaning up def/spec references

For testing purposes jsonified bar chart spec:

```
{
  "type": "serial",
  "rotate": false,
  "theme": "calcite",
  "chartCursor": {
    "categoryBalloonEnabled": false
  },
  "graphs": [{
    "type": "column",
    "newStack": true
  }],
  "legend": {},
  "valueAxes": [ {
    "stackType": "regular"
  } ],
  "export": {
    "enabled": true
  }
}
```