### PR TITLE
Tweaks to bar and pie balloontext

### DIFF
--- a/packages/cedar-amcharts/CHANGELOG.md
+++ b/packages/cedar-amcharts/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+- Balloon Text for pie, and bar chart families has been updated to a more understandable format
+
 ## 1.0.0-beta.6
 ### Changed
 - Defaults for bar charts with legends now specify legend valueAlign and spacing

--- a/packages/cedar-amcharts/src/render/render.ts
+++ b/packages/cedar-amcharts/src/render/render.ts
@@ -48,7 +48,7 @@ function getPieBalloonText(definition: any) {
   // Set label based on whether or not there actually is a value label
   const valueLabel = !!definition.series[0].value.label ? `${definition.series[0].value.label} ` : ''
   // return balloonText
-  return `${categoryLabel}[[title]] [[percents]]% (${valueLabel}[[value]])`
+  return `<div>${categoryLabel}: [[title]]</div><div>${valueLabel}: [[percents]]% ([[value]])</div>`
 }
 
 export function fillInSpec(spec: any, definition: any) { // TODO: Figure out how to split this function up
@@ -155,7 +155,7 @@ export function fillInSpec(spec: any, definition: any) { // TODO: Figure out how
         graph.valueField = isJoined ? `${datasetName}_${series.value.field}` : series.value.field
         // TODO: map other fields besides value like color, size, etc
         // tooltip
-        graph.balloonText = `${graph.title} [[${spec.categoryField}]]: <b>[[${graph.valueField}]]</b>`
+        graph.balloonText = `<div>${series.category.label}: [[${spec.categoryField}]]</div><div>${graph.title}: [[${graph.valueField}]]</div>`
 
         // Group vs. stack
         if (!!series.stack && graph.newStack) {

--- a/packages/cedar-amcharts/src/render/render.ts
+++ b/packages/cedar-amcharts/src/render/render.ts
@@ -46,9 +46,9 @@ function getPieBalloonText(definition: any) {
   // Set label based on whether or not there actually is a category label
   const categoryLabel = !!definition.series[0].category.label ? `${definition.series[0].category.label}: ` : ''
   // Set label based on whether or not there actually is a value label
-  const valueLabel = !!definition.series[0].value.label ? `${definition.series[0].value.label} ` : ''
+  const valueLabel = !!definition.series[0].value.label ? `${definition.series[0].value.label}: ` : ''
   // return balloonText
-  return `<div>${categoryLabel}: [[title]]</div><div>${valueLabel}: [[percents]]% ([[value]])</div>`
+  return `<div>${categoryLabel}[[title]]</div><div>${valueLabel}[[percents]]% ([[value]])</div>`
 }
 
 export function fillInSpec(spec: any, definition: any) { // TODO: Figure out how to split this function up

--- a/packages/cedar-amcharts/test/data/builtBarSpec.ts
+++ b/packages/cedar-amcharts/test/data/builtBarSpec.ts
@@ -11,7 +11,7 @@ const builtBarSpec = {
       "type": "column",
       "title": "Number of Students",
       "valueField": "Number_of_SUM",
-      "balloonText": "Number of Students [[Type]]: <b>[[Number_of_SUM]]</b>",
+      "balloonText": "<div>Type: [[Type]]</div><div>Number of Students: [[Number_of_SUM]]</div>",
       "newStack": true
     }
   ],

--- a/packages/cedar-amcharts/test/render/render.spec.ts
+++ b/packages/cedar-amcharts/test/render/render.spec.ts
@@ -191,7 +191,7 @@ describe('when filling in a line spec', () => {
   })
   test('should have graphed the series', () => {
     /* tslint:disable quotemark object-literal-key-quotes */
-    const expected = [{"balloonText": "Minor Injuries [[EXPR_1]]: <b>[[MINORINJURIES_SUM]]</b>", "bullet": "circle", "bulletAlpha": 1, "bulletBorderAlpha": 0.8, "bulletBorderThickness": 0, "dashLengthField": "dashLengthLine", "fillAlphas": 0, "title": "Minor Injuries", "useLineColorForBulletBorder": true, "valueField": "MINORINJURIES_SUM"}]
+    const expected = [{"balloonText": "<div>Year: [[EXPR_1]]</div><div>Minor Injuries: [[MINORINJURIES_SUM]]</div>", "bullet": "circle", "bulletAlpha": 1, "bulletBorderAlpha": 0.8, "bulletBorderThickness": 0, "dashLengthField": "dashLengthLine", "fillAlphas": 0, "title": "Minor Injuries", "useLineColorForBulletBorder": true, "valueField": "MINORINJURIES_SUM"}]
     /* tslint:enable */
     expect(result.graphs).toEqual(expected)
   })
@@ -226,11 +226,11 @@ describe('When rendering a pie chart', () => {
   })
   test('balloonText should be properly filled in', () => {
     const chart = renderChart('blah', definitions.pie, [])
-    expect(chart.balloonText).toEqual('Type: [[title]] [[percents]]% (Number of Students [[value]])')
+    expect(chart.balloonText).toEqual('<div>Type: [[title]]</div><div>Number of Students: [[percents]]% ([[value]])</div>')
   })
   test('It should handle missing category labels', () => {
     const chart = renderChart('blah', definitions.pieMissingLabels, [])
-    expect(chart.balloonText).toEqual('[[title]] [[percents]]% ([[value]])')
+    expect(chart.balloonText).toEqual('<div>[[title]]</div><div>[[percents]]% ([[value]])</div>')
   })
   afterEach(() => {
     // clean up

--- a/packages/cedar/CHANGELOG.md
+++ b/packages/cedar/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Balloon Text for pie, and bar chart families has been updated to a more understandable format
 
 ## [1.0.0-beta.7]
 ### Changed


### PR DESCRIPTION
@tomwayson The line story now has the following formats for balloon text as AC (which is why I changed pie)

```
a default tooltip for pie - "CategoryLabel: $CategoryValue ValueLabel: %n ($Value)"
a default tooltip for scatter/bubble "CategoryLabel: $CategoryValue ValueLabel: $Value"
a default for everything else (bar/line) “CategoryLabel: $CategoryValue ValueLabel: $Value”
```