### PR TITLE
Colors added to styles

### DIFF
--- a/packages/cedar-amcharts/CHANGELOG.md
+++ b/packages/cedar-amcharts/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+- style.colors accepts an array of colors that map to chart colors
 ### Changed
 - Balloon Text for pie, and bar chart families has been updated to a more understandable format
 

--- a/packages/cedar-amcharts/src/render/render.ts
+++ b/packages/cedar-amcharts/src/render/render.ts
@@ -139,6 +139,10 @@ export function fillInSpec(spec: any, definition: any) { // TODO: Figure out how
       // How far a pie chart slice will pull out when selected. Can be a number for pixels or a percent
       if (pie.hasOwnProperty('expand')) { spec.pullOutRadius = pie.expand }
     }
+
+    if (style.colors && Array.isArray(style.colors)) {
+      spec.colors = style.colors
+    }
   }
 
   // Iterate over datasets

--- a/packages/cedar-amcharts/test/render/render.spec.ts
+++ b/packages/cedar-amcharts/test/render/render.spec.ts
@@ -151,7 +151,7 @@ describe('When filling in style', () => {
         right: 10,
         left: 10
       },
-      colors: ['BB4040', '2C6175', '95B23D']
+      colors: ['#BB4040', '#2C6175', '#95B23D']
     }
     const spec = fetchSpec(definition.type)
     result = fillInSpec(spec, definition)
@@ -178,7 +178,7 @@ describe('When filling in style', () => {
     expect(result.marginRight).toEqual(10)
   })
   test('spec.colors should be an array that contains the proper colors', () => {
-    expect(result.colors).toEqual(['BB4040', '2C6175', '95B23D'])
+    expect(result.colors).toEqual(['#BB4040', '#2C6175', '#95B23D'])
   })
   afterAll(() => {
     // clean up

--- a/packages/cedar-amcharts/test/render/render.spec.ts
+++ b/packages/cedar-amcharts/test/render/render.spec.ts
@@ -150,7 +150,8 @@ describe('When filling in style', () => {
         bottom: 10,
         right: 10,
         left: 10
-      }
+      },
+      colors: ['BB4040', '2C6175', '95B23D']
     }
     const spec = fetchSpec(definition.type)
     result = fillInSpec(spec, definition)
@@ -175,6 +176,9 @@ describe('When filling in style', () => {
   })
   test('spec.marginRight should be 10 if definition.style.padding.right: 10 is passed in', () => {
     expect(result.marginRight).toEqual(10)
+  })
+  test('spec.colors should be an array that contains the proper colors', () => {
+    expect(result.colors).toEqual(['BB4040', '2C6175', '95B23D'])
   })
   afterAll(() => {
     // clean up

--- a/packages/cedar/CHANGELOG.md
+++ b/packages/cedar/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+- style.colors accepts an array of colors that map to chart colors
 ### Changed
 - Balloon Text for pie, and bar chart families has been updated to a more understandable format
 

--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -26,7 +26,8 @@ export interface IPadding {
 
 export interface IStyle {
   pie?: IPie
-  padding?: IPadding
+  padding?: IPadding,
+  colors?: string[]
 }
 
 export interface IDefinition {


### PR DESCRIPTION
@tomwayson just putting this up without tests yet to see if you 👍 the implementation. It should be gtg and tested with the various chart types. Just add: if you wanna play with it.

```
  "style": {
      "colors": ["red", "pink", "yellow"]
  }
```

Closes #436