### PR TITLE
stop bundling @esri/rest-* and export everything as an ES6 module 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ packages/cedar/README.md
 docs/scripts/
 
 .vscode
+
+packages/*/.rpt2_cache

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
       }
       .footer {
         text-align: center;
-      }      
+      }
     </style>
   </head>
   <body id="" onload="">
@@ -47,13 +47,13 @@
       <div class="col-md-12">
         <h1>@esri/cedar</h1>
         <p>Select a chart type to see the chart and the JSON used to create it. Update the JSON and click "Update Chart".
-          Learn more at our <a href="https://github.com/esri/cedar">GitHub repository</a>, or see the <a href="http://cedar-v0.surge.sh/">v0.x documentation</a>.</p>    
+          Learn more at our <a href="https://github.com/esri/cedar">GitHub repository</a>, or see the <a href="http://cedar-v0.surge.sh/">v0.x documentation</a>.</p>
       </div>
     </div>
     <div class="row">
       <div class="col-md-2">
         <div id="styleList">
-          <h3>Chart Type</h3>      
+          <h3>Chart Type</h3>
         </div>
       </div>
       <div class="col-md-4">
@@ -82,8 +82,8 @@
   <script src="https://www.amcharts.com/lib/3/plugins/export/export.min.js"></script>
   <link rel="stylesheet" href="https://www.amcharts.com/lib/3/plugins/export/export.css" type="text/css" media="all" />
   <!-- load the arcgis-rest-js scripts -->
-  <script src="https://unpkg.com/@esri/arcgis-rest-request@1.7.1/dist/umd/request.umd.min.js"></script>
-  <script src="https://unpkg.com/@esri/arcgis-rest-feature-service@1.7.1/dist/umd/feature-service.umd.min.js"></script>
+  <script src="https://unpkg.com/@esri/arcgis-rest-request"></script>
+  <script src="https://unpkg.com/@esri/arcgis-rest-feature-service"></script>
     <!-- optionally load calcite theme -->
   <script src="./scripts/themes/amCharts/calcite.js"></script>
   <!-- load cedar -->
@@ -106,7 +106,7 @@
       };
       document.head.appendChild(js);
     }
-    
+
     function main(err) {
       // Initiate all other code paths.
       // If there's an error loading the polyfills, handle that

--- a/packages/cedar/profiles/base.js
+++ b/packages/cedar/profiles/base.js
@@ -14,13 +14,18 @@ export default {
   output: {
     name: 'cedar',
     format: 'umd',
-    external: ['@esri/arcgis-rest-feature-service'],
     globals: {
       '@esri/arcgis-rest-feature-service': 'arcgisRest'
     },
-    banner: copyright  
+    banner: copyright
   },
+  external: [
+    '@esri/arcgis-rest-feature-service'
+  ],
   // NOTE: using node resolve to bundle an older version of deepmerge
   // if we move to latest, we _may_ want to make that external instead
-  plugins: [json(), resolve()],
+  plugins: [
+    json(),
+    resolve()
+  ],
 };

--- a/packages/cedar/profiles/dev.js
+++ b/packages/cedar/profiles/dev.js
@@ -1,6 +1,6 @@
 import config from './base';
 
 config.output.file = 'dist/umd/cedar.js';
-config.output.sourcemap = 'dist/umd/cedar.js.map';
+config.output.sourcemap = true;
 
 export default config;

--- a/packages/cedar/src/Chart.ts
+++ b/packages/cedar/src/Chart.ts
@@ -40,7 +40,7 @@ export interface IDefinition {
   style?: IStyle
 }
 
-export default class Chart {
+export class Chart {
   private _container: string
   private _definition: IDefinition
   private _data: any[]

--- a/packages/cedar/src/index.ts
+++ b/packages/cedar/src/index.ts
@@ -1,7 +1,8 @@
-import Chart from './Chart'
-import config from './config'
+/* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
+ * Apache-2.0 */
 
-export default {
-  Chart,
-  config
-}
+ export * from './Chart';
+ export * from './dataset';
+ export * from './config';
+ export * from './query/query';
+ export * from './query/url';


### PR DESCRIPTION
resolves #391 
resolves https://github.com/Esri/cedar/pull/450#discussion_r234125266

making sure i didn't bust the website and the dummy app below were the extent of my testing.
<img width="967" alt="screenshot 2018-11-27 09 35 44" src="https://user-images.githubusercontent.com/3011734/49100068-dcfcc700-f227-11e8-9c32-33d0fea88982.png">

