### PR TITLE
include v0.x json in v1 doc page

### DIFF
--- a/docs/js/charts/README.md
+++ b/docs/js/charts/README.md
@@ -1,0 +1,3 @@
+these JSON files are for use with cedar v0.x. they are hosted on github pages for backwards compatibility
+
+see https://github.com/Esri/cedar/issues/458 for more information.

--- a/docs/js/charts/bar-horizontal.json
+++ b/docs/js/charts/bar-horizontal.json
@@ -1,0 +1,119 @@
+{
+  "inputs": [
+    { "name": "x", "type": [ "numeric", "string" ], "required": true },
+    { "name": "y", "type": [ "string" ], "required": true }
+  ],
+  "query": {
+    "orderByFields": "{x.field} DESC",
+    "groupByFieldsForStatistics": "{y.field}",
+    "outStatistics": [{
+        "statisticType": "sum",
+        "onStatisticField": "{x.field}",
+        "outStatisticFieldName": "{x.field}"
+    }]
+  },
+  "template":{
+    "padding": "strict",
+    "axes": [
+      {
+        "type": "x",
+        "scale": "x",
+        "titleOffset": 45,
+        "title": "{x.label}",
+        "tickPadding": 10,        
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "baseline": {"value": "middle"}
+          }
+        }
+      },
+      {
+        "type": "y",
+        "scale": "y",
+        "titleOffset": 25,
+        "title": "{y.label}",
+        "padding": 0.25,
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "baseline": {"value": "middle"}
+          }
+        }
+      }      
+    ],
+    "data": [
+      {
+        "name": "table",
+        "format": {"property": "features"}
+      }
+    ],    
+    "marks": [
+      {
+        "from": {"data": "table"},
+        "properties": {
+          "enter": {
+            "height": {"band": true, "offset": -1, "scale": "y"},
+            "y": {"scale": "y", "field": "attributes.{y.field}"},
+            "x2": {"scale": "x", "field": "attributes.{x.field}"},
+            "x": {"scale": "x", "value": 0 }
+          },
+          "hover": {
+            "fill": {"value": "#29b6ea"}
+          },
+          "update": {
+            "fill": {"value": "#0079c1"}
+          }
+        },
+        "type": "rect"
+      }
+    ],    
+    "scales": [
+      {
+        "domain": {
+          "data": "table",
+          "field": "attributes.{y.field}"
+        },
+        "name": "y",
+        "range": "height",
+        "type": "ordinal",
+        "padding": 0.25
+      },
+      {
+        "domain": {
+          "data": "table",
+          "field": "attributes.{x.field}"
+        },
+        "name": "x",
+        "nice": true,
+        "range": "width"
+      }
+    ]
+  }
+}

--- a/docs/js/charts/bar.json
+++ b/docs/js/charts/bar.json
@@ -1,0 +1,108 @@
+{
+  "inputs": [
+    { "name": "x", "type": [ "string" ], "required": true },
+    { "name": "y", "type": [ "numeric" ], "required": true }
+  ],
+  "query": {},
+  "template":{
+    "padding": "strict",
+    "axes": [
+      {
+        "type": "x",
+        "scale": "x",
+        "titleOffset": 45,
+        "title": "{x.label}",          
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },          
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": -50},
+            "align": {"value": "right"},
+            "baseline": {"value": "middle"}
+          }
+        }
+      },
+      {
+        "type": "y",
+        "scale": "y",
+        "titleOffset": 45,
+        "title": "{y.label}",
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },          
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"}
+          }
+        }
+      }      
+    ],
+    "data": [
+      {
+        "name": "table",
+        "format": {"property": "features"}
+      }
+    ],    
+    "marks": [
+      {
+        "from": {"data": "table"},
+        "properties": {
+          "enter": {
+          },
+          "update": {
+            "width": {"band": true, "offset": -1, "scale": "x"},
+            "x": {"field": "attributes.{x.field}", "scale": "x"},
+            "y": {"field": "attributes.{y.field}", "scale": "y"},
+            "y2": {"scale": "y", "value": 0 },            
+            "fill": {"value": "#0079c1"}
+          },
+          "hover": {
+            "fill": {"value": "#29b6ea"}
+          }
+        },
+        "type": "rect"
+      }
+    ],    
+    "scales": [
+      {
+        "domain": {
+          "data": "table",
+          "field": "attributes.{x.field}"
+        },
+        "name": "x",
+        "range": "width",
+        "type": "ordinal",
+        "padding": 0.25
+      },
+      {
+        "domain": {
+          "data": "table",
+          "field": "attributes.{y.field}"
+        },
+        "name": "y",
+        "nice": true,
+        "range": "height"
+      }
+    ]
+  }
+}

--- a/docs/js/charts/bubble.json
+++ b/docs/js/charts/bubble.json
@@ -1,0 +1,161 @@
+{
+  "inputs": [
+    {"name":"x","type":["numeric"], "required":true},
+    {"name":"y","type":["numeric"], "required":true},
+    {"name":"size","type":["numeric"], "default": 100, "required":false}
+  ],
+  "template":{
+    "padding": "strict",
+    "data": [
+      {
+        "name": "table",
+        "format": {
+          "property": "features"
+        }
+      }
+    ],
+    "scales": [
+      {
+        "name": "x",
+        "nice": true,
+        "range": "width",
+        "domain": {
+          "data": "table",
+          "field": "attributes.{x.field}"
+        }
+      },
+      {
+        "name": "y",
+        "nice": true,
+        "range": "height",
+        "domain": {
+          "data": "table",
+          "field": "attributes.{y.field}"
+        }
+      },
+      {
+        "name": "size",
+        "type": "sqrt",
+        "domain": {
+          "data": "table",
+          "field": "attributes.{size.field}"
+        },
+        "range": [0,2000]
+      }
+    ],
+    "axes": [
+      {
+        "type": "x",
+        "scale": "x",
+        "offset": 5,
+        "ticks": 5,
+        "title": "{x.label}",
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "fontSize": {"value": 14},
+            "align": {"value": "left"},
+            "baseline": {"value": "middle"},
+            "dx": {"value": 3}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          }
+        }        
+      },
+      {
+        "type": "y",
+        "scale": "y",
+        "offset": 5,
+        "ticks": 5,
+        "title": "{y.label}",
+        "titleOffset": 50,
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "fontSize": {"value": 14},
+            "align": {"value": "right"}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          }
+        }
+      }
+    ],
+    "legends": [
+      {
+        "title": "{size.label}",
+        "offset": 0,
+        "size": "size",
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "bold"}
+          },
+          "symbols": {
+            "strokeWidth": {"value": 2},
+            "stroke": {"value": "#0079c1"},
+            "fill": { "value": "#fff" },
+            "fillOpacity": {"value": 0.4 }
+          }
+        }
+      }
+    ],
+    "marks": [
+      {
+        "type": "symbol",
+        "from": {
+          "data": "table"
+        },
+        "properties": {
+          "enter": {
+            "x": {
+              "scale": "x",
+              "field": "attributes.{x.field}"
+            },
+            "y": {
+              "scale": "y",
+              "field": "attributes.{y.field}"
+            },
+            "strokeWidth": {"value": 2},
+            "fillOpacity": {"value": 0.4 },
+            "size": { 
+              "scale": "size",
+              "field": "attributes.{size.field}"
+            }
+          },
+          "update": {
+            "fill": { "value": "#fff" },
+            "stroke": {"value": "#0079c1"}
+          },
+          "hover": {
+            "fill": {"value": "#0079c1"},
+            "fillOpacity": {"value": 0.6 },
+            "stroke": {"value": "#0079c1"}
+          }
+        }
+      }
+    ]
+  }
+}

--- a/docs/js/charts/grouped.json
+++ b/docs/js/charts/grouped.json
@@ -1,0 +1,232 @@
+{
+    "inputs": [
+        {
+            "name": "x",
+            "required": true,
+            "type": [
+                "numeric",
+                "string"
+            ]
+        },
+        {
+            "name": "group",
+            "required": true,
+            "type": [
+                "string"
+            ]
+        }
+    ],
+    "query": {},
+    "template": {
+        "axes": [
+            {
+                "properties": {
+                    "axis": {
+                        "stroke": {
+                            "value": "#dbdad9"
+                        },
+                        "strokeWidth": {
+                            "value": 1.5
+                        }
+                    },
+                    "labels": {
+                        "align": {
+                            "value": "right"
+                        },
+                        "angle": {
+                            "value": -50
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        },
+                        "fill": {
+                            "value": "#999"
+                        }
+                    },
+                    "ticks": {
+                        "stroke": {
+                            "value": "#dbdad9"
+                        }
+                    },
+                    "title": {
+                        "fill": {
+                            "value": "#999"
+                        },
+                        "fontSize": {
+                            "value": 15
+                        },
+                        "fontWeight": {
+                            "value": "normal"
+                        }
+                    }
+                },
+                "scale": "cat",
+                "tickPadding": 8,
+                "tickSize": 0,
+                "type": "x"
+            },
+            {
+                "grid": true,
+                "layer": "back",
+                "properties": {
+                    "axis": {
+                        "stroke": {
+                            "value": "#dbdad9"
+                        },
+                        "strokeWidth": {
+                            "value": 1.5
+                        }
+                    },
+                    "labels": {
+                        "fill": {
+                            "value": "#999"
+                        }
+                    },
+                    "ticks": {
+                        "stroke": {
+                            "value": "#dbdad9"
+                        }
+                    },
+                    "title": {
+                        "fill": {
+                            "value": "#999"
+                        },
+                        "fontSize": {
+                            "value": 15
+                        },
+                        "fontWeight": {
+                            "value": "normal"
+                        }
+                    }
+                },
+                "scale": "val",
+                "type": "y"
+            }
+        ],
+        "data": [
+            {
+                "format": {
+                    "property": "features"
+                },
+                "name": "table",
+                "transform": [
+                    {
+                        "fields": "{x.field}",
+                        "output": {
+                            "key": "group",
+                            "value": "count"
+                        },
+                        "type": "fold"
+                    }
+                ]
+            }
+        ],
+        "legends": [
+            {
+                "fill": "color",
+                "title": "{x.label}"
+            }
+        ],
+        "marks": [
+            {
+                "from": {
+                    "data": "table",
+                    "transform": [
+                        {
+                            "groupby": [
+                                "attributes.{group.field}"
+                            ],
+                            "type": "facet"
+                        }
+                    ]
+                },
+                "marks": [
+                    {
+                        "name": "bars",
+                        "properties": {
+                            "enter": {
+                                "fill": {
+                                    "field": "group",
+                                    "scale": "color"
+                                },
+                                "width": {
+                                    "band": true,
+                                    "scale": "pos"
+                                },
+                                "x": {
+                                    "field": "group",
+                                    "scale": "pos"
+                                },
+                                "y": {
+                                    "field": "count",
+                                    "scale": "val"
+                                },
+                                "y2": {
+                                    "scale": "val",
+                                    "value": 0
+                                }
+                            }
+                        },
+                        "type": "rect"
+                    }
+                ],
+                "properties": {
+                    "enter": {
+                        "height": {
+                            "band": true,
+                            "scale": "cat"
+                        },
+                        "x": {
+                            "field": "key",
+                            "scale": "cat"
+                        }
+                    }
+                },
+                "scales": [
+                    {
+                        "domain": {
+                            "field": "group"
+                        },
+                        "name": "pos",
+                        "range": "height",
+                        "type": "ordinal"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "padding": "strict",
+        "scales": [
+            {
+                "domain": {
+                    "data": "table",
+                    "field": "attributes.{group.field}"
+                },
+                "name": "cat",
+                "padding": 0.2,
+                "range": "width",
+                "type": "ordinal"
+            },
+            {
+                "domain": {
+                    "data": "table",
+                    "field": "count"
+                },
+                "name": "val",
+                "nice": true,
+                "range": "height",
+                "round": true,
+                "type": "linear"
+            },
+            {
+                "domain": {
+                    "data": "table",
+                    "field": "group"
+                },
+                "name": "color",
+                "range": "category20",
+                "type": "ordinal"
+            }
+        ]
+    }
+}

--- a/docs/js/charts/pie.json
+++ b/docs/js/charts/pie.json
@@ -1,0 +1,80 @@
+{
+  "inputs": [
+    {"name": "y", "type": ["numeric","string"], "required": true},
+    {"name": "label", "type": ["string"], "required": false},
+    {"name": "radius", "type": ["numeric"], "default": 200, "required": false}
+  ],
+  "template":{
+    "padding": "strict",
+    "data": [
+      {
+        "name": "table",
+        "format": {
+          "property": "features"
+        },
+        "transform": [
+          {"type": "pie", "field": "attributes.{y.field}"},
+          {"type": "formula", "field": "hyp", "expr": "{radius}"},
+          {"type": "formula", "field": "theta", "expr": "datum.layout_start + 0.5 *(datum.layout_end - datum.layout_start) - 1.57079633"},
+          {"type": "formula", "field": "x", "expr": "datum.hyp * cos(datum.theta)"},
+          {"type": "formula", "field": "y", "expr": "datum.hyp * sin(datum.theta)"}     
+        ]
+      }
+    ],
+    "scales": [
+      {
+        "name": "r",
+        "type": "sqrt",
+        "domain": {"data": "table", "field": "attributes.{y.field}"}
+      },
+      {
+        "name": "color",
+        "type": "ordinal",
+        "domain": {
+          "data": "table",
+          "field": "attributes.{label.field}"
+        },
+        "range": "category10"
+      }
+    ],
+    "marks": [
+      {
+        "type": "arc",
+        "from": {"data": "table"},
+        "properties": {
+          "enter": {
+            "x": {"group": "width"},
+            "y": {"group": "height"},
+            "startAngle": {"field": "layout_start"},
+            "endAngle": {"field": "layout_end"},
+            "outerRadius": {"value": "{radius}"},
+            "stroke": {"value": "#fff"}
+          },
+          "update": {
+            "fill": {"scale": "color", "field": "attributes.{label.field}"},
+            "fillOpacity": {"value": 1}
+          },
+          "hover": {
+            "fillOpacity": {"value": 0.8}
+          }
+        }
+      },
+      {
+        "type": "text",
+        "from": {"data": "table"},
+        "properties": {
+          "enter": {
+            "fill": {"value": "#fff"},
+            "y": {"field": "y", "mult": 0.6},
+            "x": {"field": "x", "mult": 0.6},
+            "fill": {"value": "#fff"},
+            "align": {"value": "center"},
+            "baseline": {"value": "middle"},
+            "text": {"field": "attributes.{label.field}"}
+          }
+        }
+      }
+    ]
+  }
+  
+}

--- a/docs/js/charts/scatter.json
+++ b/docs/js/charts/scatter.json
@@ -1,0 +1,165 @@
+{
+  "inputs":[
+    {"name":"x","type":["numeric"], "required":true},
+    {"name":"y","type":["numeric"], "required":true},
+    {"name":"color","type":["string"], "default": "#0079c1", "required":false}
+  ],
+  "template":{
+    "padding": "strict",
+    "data": [
+      {
+        "name": "table",
+        "format": {
+          "property": "features"
+        }
+      }
+    ],
+    "scales": [
+      {
+        "name": "x",
+        "nice": true,
+        "range": "width",
+        "domain": {
+          "data": "table",
+          "field": "attributes.{x.field}"
+        }
+      },
+      {
+        "name": "y",
+        "nice": true,
+        "range": "height",
+        "domain": {
+          "data": "table",
+          "field": "attributes.{y.field}"
+        }
+      },
+      {
+        "name": "c",
+        "type": "ordinal",
+        "domain": {
+          "data": "table",
+          "field": "attributes.{color.field}"
+        },
+        "range": "category10"
+      }
+    ],
+    "axes": [
+      {
+        "type": "x",
+        "scale": "x",
+        "title": "{x.label}",
+        "tickPadding": 10,
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "fontSize": {"value": 14},
+            "align": {"value": "center"},
+            "baseline": {"value": "middle"}
+          }
+        }        
+      },
+      {
+        "type": "y",
+        "scale": "y",
+        "offset": 5,
+        "ticks": 5,
+        "title": "{y.label}",
+        "titleOffset": 50,
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "angle": {"value": 0},
+            "fontSize": {"value": 14},
+            "align": {"value": "right"}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1.5}
+          }
+        }
+      }
+    ],
+    "legends": [
+      {
+        "fill": "c",
+        "title": "{color.label} ",
+        "offset": 0,
+        "properties": {
+          "symbols": {
+            "fillOpacity": {
+              "value": 0.5
+            },
+            "stroke": {
+              "value": "transparent"
+            }
+          }
+        }
+      }
+    ],
+    "marks": [
+      {
+        "type": "symbol",
+        "from": {
+          "data": "table"
+        },
+        "properties": {
+          "enter": {
+            "x": {
+              "scale": "x",
+              "field": "attributes.{x.field}"
+            },
+            "y": {
+              "scale": "y",
+              "field": "attributes.{y.field}"
+            },
+            "fill": {
+              "scale": "c",
+              "field": "attributes.{color.field}"
+            },
+            "fillOpacity": {
+              "value": 0.5
+            }
+          },
+          "update": {
+            "size": {
+              "value": 100
+            },
+            "stroke": {
+              "value": "transparent"
+            }
+          },
+          "hover": {
+            "size": {
+              "value": 300
+            },
+            "stroke": {
+              "value": "white"
+            }
+          }
+        }
+      }
+    ]
+  }
+  
+}

--- a/docs/js/charts/sparkline.json
+++ b/docs/js/charts/sparkline.json
@@ -1,0 +1,41 @@
+{
+  "inputs": [
+    { "name": "x", "type": [ "datetime" ], "required": true },
+    { "name": "y", "type": [ "number" ], "required": true }
+  ],
+  "template":{
+    "data": [{
+      "name": "table",
+      "format": {"type": "json", "parse": {"attributes.{x.field}":"date"}}
+    }],
+    "padding": {"top": 0, "left": 0, "bottom": 0, "right": 0},
+    "scales": [
+      {
+        "name": "x",
+        "type": "time",
+        "range": "width",
+  	     "zero": false,
+        "domain": {"data": "table", "field": "attributes.{x.field}"}
+      },
+      {
+        "name": "y",
+        "type": "linear",
+        "range": "height",
+  	     "zero": false,
+        "domain": {"data": "table", "field": "attributes.{y.field}"}
+      }
+    ],
+    "marks": [{
+  		"type": "line",
+  		"from": {"data": "table"},
+  			"properties": {
+  			"enter": {
+  			  "x": {"scale": "x", "field": "attributes.{x.field}"},
+  			  "y": {"scale": "y", "field": "attributes.{y.field}"},
+  			  "stroke": {"value": "#f00"},
+  			  "strokeWidth": {"value": 1}
+  			}
+  		}
+    }]
+  }
+}

--- a/docs/js/charts/time-trendline.json
+++ b/docs/js/charts/time-trendline.json
@@ -1,0 +1,116 @@
+{
+  "inputs":[
+    {"name":"time","type":["time"], "required":true},
+    {"name":"value","type":["numeric"], "required":true},
+    {"name":"trendline","type":["numeric"], "required":true}
+  ],
+  "template":{
+    "padding": "strict",
+    "data": [
+      {
+        "name": "table",
+        "url":"{data}&orderByFields={time.field}",
+        "format": {"type": "json", "property": "features", "parse": {"attributes.{time.field}":"date"}}
+      },
+      {
+        "name": "exports",
+        "source": "table",
+        "transform": [
+          {"type": "formula", "field": "export", "expr": "datum"}
+        ]
+      }
+    ],
+    "scales": [
+      {
+        "name": "x",
+        "type": "time",
+        "range": "width",
+        "nice": "month",
+        "zero": false,
+        "domain": {"data": "table", "field": "attributes.{time.field}"}
+      },
+      {
+        "name": "y",
+        "type": "linear",
+        "range": "height",
+        "nice": true,
+        "domain": {"data": "table", "field": "attributes.{value.field}"}
+      }
+    ],
+    "axes": [
+      {
+        "type": "x", 
+        "scale": "x",
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },
+          "ticks": {
+            "strokeWidth" : {"value" :0}          
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "fontSize": {"value": 13}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 0}
+          }
+        }
+      },
+      {
+        "type": "y", 
+        "scale": "y",
+        "ticks": 5,
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },          
+          "ticks": {
+             "strokeWidth" : {"value" :0}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "fontSize": {"value": 13}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 0}
+          }
+        }
+      }
+    ],
+    "marks": [
+      {
+        "type": "line",
+        "from": {"data": "table"},
+        "properties": {
+          "enter": {
+            "x": {"scale": "x", "field": "attributes.{time.field}"},
+            "y": {"scale": "y", "field": "attributes.{value.field}"},
+            "stroke": {"value": "#0079c1"},
+            "strokeWidth" : { "value" : 3}
+          }
+        }
+      },
+      {
+        "type": "line",
+        "from": {"data": "table"},
+        "properties": {
+          "enter": {
+            "x": {"scale": "x", "field": "attributes.{time.field}"},
+            "y": {"scale": "y", "field": "attributes.{trendline.field}"},
+            "stroke": {"value": "#000000"},
+            "strokeWidth" : { "value" : 3},
+            "strokeDash" : { "value" : [7, 2]}
+          }
+        }
+      }
+
+    ]
+  }
+}

--- a/docs/js/charts/time.json
+++ b/docs/js/charts/time.json
@@ -1,0 +1,126 @@
+{
+  "inputs":[
+    {"name":"time","type":["time"], "required":true},
+    {"name":"value","type":["numeric"], "required":true}
+  ],
+  "template":{
+    "padding": "strict",
+    "data": [
+      {
+        "name": "table",
+        "url":"{data}&orderByFields={time.field}",
+        "format": {"type": "json", "property": "features", "parse": {"attributes.{time.field}":"date"}}
+      },
+      {
+        "name": "exports",
+        "source": "table",
+        "transform": [
+          {"type": "formula", "field": "export", "expr": "datum"}
+        ]
+      }
+    ],
+    "scales": [
+      {
+        "name": "x",
+        "type": "time",
+        "range": "width",
+        "zero": false,
+        "domain": {"data": "table", "field": "attributes.{time.field}"}
+      },
+      {
+        "name": "y",
+        "type": "linear",
+        "range": "height",
+        "nice": true,
+        "domain": {"data": "table", "field": "attributes.{value.field}"}
+      }
+    ],
+    "axes": [
+      {
+        "type": "x",
+        "scale": "x",
+        "titleOffset": 60,
+        "title": "{time.label}",
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "fontSize": {"value": 13}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"},
+             "strokeWidth": {"value": 1}
+          }
+        }
+      },
+      {
+        "type": "y",
+        "scale": "y",
+        "ticks": 5,
+        "titleOffset": 45,
+        "title": "{value.label}",
+        "properties": {
+          "title": {
+            "fontSize": {"value": 15},
+            "fill": {"value": "#999"},
+            "fontWeight": {"value": "normal"}
+          },
+          "ticks": {
+             "stroke": {"value": "#dbdad9"}
+          },
+          "labels": {
+            "fill": {"value": "#999"},
+            "fontSize": {"value": 13}
+          },
+          "axis": {
+             "stroke": {"value": "#dbdad9"}
+          }
+        }
+      }
+    ],
+    "marks": [
+      {
+        "type": "symbol",
+        "from": {"data": "table"},
+        "properties": {
+          "enter": {
+            "x": {"scale": "x", "field": "attributes.{time.field}"},
+            "y": {"scale": "y", "field": "attributes.{value.field}"},
+            "stroke": {"value": "#0079c1"},
+            "fill": {"value": "#0079c1"},
+            "size": {"value": 20},
+            "fillOpacity": {
+              "value": 0.8
+            },
+            "hover": {
+              "fill": {"value": "#0079c1"},
+              "size": {"value": 25}
+            },
+            "update": {
+              "fill": {"value": "#f00"}
+            }
+          }
+        }
+      },
+      {
+        "type": "line",
+        "from": {"data": "table"},
+        "properties": {
+          "enter": {
+            "x": {"scale": "x", "field": "attributes.{time.field}"},
+            "y": {"scale": "y", "field": "attributes.{value.field}"},
+            "y2": {"scale": "y", "value": 0},
+            "stroke": {"value": "#0079c1"}
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
> add a step to the v1.x docs deploy process that pushes the v0.9.2 /charts folder to the above location

it seems too convoluted to introduce logic to check out an entirely different branch, copy files and switch back to the original branch before deploying the docs to github pages.

would a simple one time copy/paste work? it doesn't look like we've had a 0.x release since early 2017.

