### PR TITLE
Added tabIndex properties

### DIFF
--- a/packages/cedar-amcharts/CHANGELOG.md
+++ b/packages/cedar-amcharts/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Add tabindex properties to fillInSpec
 
 ## 1.0.0-rc.1
 

--- a/packages/cedar-amcharts/src/render/render.ts
+++ b/packages/cedar-amcharts/src/render/render.ts
@@ -61,6 +61,9 @@ export function fillInSpec(spec: any, definition: any) { // TODO: Figure out how
   // otherwise get it from the first series
   spec.categoryField = isJoined ? 'categoryField' : definition.series[0].category.field
 
+  // Set tabIndex for the chart
+  spec.tabIndex = 0
+
   // Add a legend in case it's not on the spec
   if (!spec.legend) { spec.legend = {} }
   // TODO This is needed as 'legend.enable' has been renamed 'legend.visible'. We are only introducing
@@ -108,6 +111,8 @@ export function fillInSpec(spec: any, definition: any) { // TODO: Figure out how
     const supportedLegendPositions: string[] = ['top', 'bottom', 'left', 'right']
     if (legend.hasOwnProperty('visible')) {
       spec.legend.enabled = legend.visible
+      // If there is a legend on the page add a tabIndex
+      spec.legend.tabIndex = 0
     }
     if (legend.position && supportedLegendPositions.indexOf(legend.position) > -1) {
       spec.legend.position = legend.position

--- a/packages/cedar-amcharts/test/data/builtBarSpec.ts
+++ b/packages/cedar-amcharts/test/data/builtBarSpec.ts
@@ -6,6 +6,7 @@ const builtBarSpec = {
   "chartCursor": {
     "categoryBalloonEnabled": false
   },
+  "tabIndex": 0,
   "graphs": [
     {
       "type": "column",


### PR DESCRIPTION
To support accessibility via amcharts3 we've now added the tabIndex properties to the spec overall, and to legend when it's in use. I would have added it to titles, however we don't make use of overall chart titles. After consulting with Klara I went with using `tabIndex: 0` for both legend and the chart overall. I did not make use of `accessibleLabel` as that seems to be something that amcharts injects on its own for the most part, and in the cases where it doesn't it is a very specific thing. IE pie chart expand interactions. 

worked from: https://www.amcharts.com/accessibility/accessible-charts-v3/