### PR TITLE
update cdn url in doc page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@
   <link rel="stylesheet" href="https://www.amcharts.com/lib/3/plugins/export/export.css" type="text/css" media="all" />
   <!-- load the arcgis-rest-js scripts -->
   <script src="https://unpkg.com/@esri/arcgis-rest-request/dist/umd/request.umd.js"></script>
-  <script src="https://unpkg.com/@esri/arcgis-rest-feature-service/dist/umd/feature-service.umd.js"></script>
+  <script src="https://unpkg.com/@esri/arcgis-rest-feature-layer/dist/umd/feature-layer.umd.js"></script>
     <!-- optionally load calcite theme -->
   <script src="./scripts/themes/amCharts/calcite.js"></script>
   <!-- load cedar -->


### PR DESCRIPTION
i tested locally and this is all that is necessary to resolve #466.
to fix the live site you _might_ have to tag a new release of `@esri/cedar` too.

if that isn't in the cards in the next couple of days, we could also version lock temporarily.

```html
<script src="https://unpkg.com/@esri/arcgis-rest-request@1.19.2/dist/umd/request.umd.js"></script>
<script src="https://unpkg.com/@esri/arcgis-rest-feature-service@1.19.2/dist/umd/feature-service.umd.js"></script>
```