### PR TITLE
"its", not "it's"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You are looking at the documentation for v1.x of cedar. You can also view the [d
 
 **NOTE:** If you want to use cedar in an Ember.js application, see [ember-cli-cedar](https://github.com/Esri/ember-cli-cedar) instead.
 
-You can install cedar and it's [dependencies](#dependencies) with npm:
+You can install cedar and its [dependencies](#dependencies) with npm:
 ```bash
 npm install --save @esri/arcgis-rest-feature-layer@^2.0.0 @esri/arcgis-rest-request@^2.0.0 amcharts3 @esri/cedar 
 ```
@@ -202,7 +202,7 @@ If you need to use other chart types, or want to use amCharts plugins, load the 
 
 ## Dependencies
 
-Cedar isn't yet another JavaScript charting library. Instead, cedar is a very thin wrapper around other libraries that do the heavy lifting. Cedar uses [amCharts](https://www.amcharts.com/javascript-charts/) library as it's charting engine. Cedar also uses [@esri/arcgis-rest-feature-layer](https://esri.github.io/arcgis-rest-js/api/feature-layer/) and [@esri/arcgis-rest-request](https://esri.github.io/arcgis-rest-js/api/request/) to query feature data. You will need to [install](#installing-cedar) these libraries along with cedar in your application. If you are loading cedar from a CDN, please refer to the [loading cedar](#loading-cedar) section above for the `<script>` tags that you will need to include.
+Cedar isn't yet another JavaScript charting library. Instead, cedar is a very thin wrapper around other libraries that do the heavy lifting. Cedar uses [amCharts](https://www.amcharts.com/javascript-charts/) library as its charting engine. Cedar also uses [@esri/arcgis-rest-feature-layer](https://esri.github.io/arcgis-rest-js/api/feature-layer/) and [@esri/arcgis-rest-request](https://esri.github.io/arcgis-rest-js/api/request/) to query feature data. You will need to [install](#installing-cedar) these libraries along with cedar in your application. If you are loading cedar from a CDN, please refer to the [loading cedar](#loading-cedar) section above for the `<script>` tags that you will need to include.
 
 Cedar supports the [same browsers as ArcGIS Online](https://doc.arcgis.com/en/arcgis-online/reference/browsers.htm), however you may need to include polyfills for [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) and [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), if your application has to support browers that don't support them (i.e. IE or older versions of Safari/Android).
 
@@ -236,7 +236,7 @@ This repository is a monorepo managed using [yarn workspaces](https://yarnpkg.co
 
 To run tests one time for all packages, run `yarn test` from the monorepo root.
 
-To run tests for any package as you update it's source code, `cd` into that package and run `yarn run test:watch` to continually run that package's tests as you make your changes.
+To run tests for any package as you update its source code, `cd` into that package and run `yarn run test:watch` to continually run that package's tests as you make your changes.
 
 ### Licensing
 Copyright &copy; 2014-2018 Esri


### PR DESCRIPTION
"it's" is a contraction of "it is". "its" is the possessive: "belonging to it". Thus sentences such as "Cedar uses amCharts library as its charting engine" need to use "its", not "it's". Of all the orthographical battles, this is one that prescriptive grammarians are steadily losing, but I try to fix this error where I can.