### PR TITLE
"its", not "it's"

### DIFF
--- a/api/interfaces/idefinition.html
+++ b/api/interfaces/idefinition.html
@@ -990,7 +990,7 @@ img { max-width: 100%; }
 		<section class="tsd-panel tsd-comment">
 			<div class="tsd-comment tsd-typography">
 				<div class="lead">
-					<p>Defines where a chart gets it&#39;s data from and how the data is rendered in the chart</p>
+					<p>Defines where a chart gets its data from and how the data is rendered in the chart</p>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
Correct erroneous "it's" ("it is") to "its" ("belonging to it").